### PR TITLE
Added optional caching for vault secrets

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -47,21 +47,19 @@ To avoid repeatedly setting up the environment during development, you can first
 
 The access information for test environments is as follows:
 
-- OpenBao: [http://127.0.0.127:8200](http://127.0.0.127:8200)
+- OpenBao: http://127.0.0.127:8200
 
   To get the root token and unseal key run
   ```
   kubectl exec $(kubectl get pod -l app=openbao -o jsonpath='{.items[0].metadata.name}') -c openbao-configurator -- cat /unseal/init.json
   ```
-- Keycloak: [http://127.0.0.127:8080](http://127.0.0.127:8080)
+- Keycloak: http://127.0.0.127:8080 (pod keycloak-0) and http://127.0.0.127:8081 (pod keycloak-1)
 
   Admin credentials: `admin` / `admin`
 
-- Federated realm login: [http://127.0.0.127:8080/realms/first/account/](http://127.0.0.127:8080/realms/first/account/)
+- Federated realm login: http://127.0.0.127:8080/realms/first/account/
 
   User in "second" realm: `joe` / `joe`
-
-
 
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -100,3 +100,16 @@ Secrets are automatically restricted to the specific Keycloak realm in which the
 A secret named `ldap-bindpw` created in `my-realm` is not the same as `ldap-bindpw` in `your-realm`.
 
 Secrets Manager is accessible only via the REST API and a user interface within Keycloak Admin Console is not available.
+
+## Caching of Secrets
+
+If vault references are accessed often, connecting to OpenBao or HashiCorp Vault every time can add considerable overhead.
+The extension supports caching of secrets in memory after they are first read.
+Keycloak’s Infinispan is used for this purpose.
+When the same secret is accessed again, it is returned from the cache instead of making a new request.
+
+For caching to work properly, both the Vault SPI provider and the Secrets Manager REST API extension must be set up to use the same cache.
+When a secret is updated or deleted through the Secrets Manager REST API, the cached value is removed from the Infinispan cache.
+This ensures that the next request will always get the latest value.
+If a secret is changed or deleted directly from OpenBao or HashiCorp Vault (not through the Secrets Manager), the extension will not know about it and returns the old value from the cache.
+Cache can be configured with eviction policy to expire the cached secrets periodically to ensure eventual consistency.

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-model-infinispan</artifactId>
+        <version>${version.keycloak}</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${version.jackson.core}</version>

--- a/src/main/java/io/github/nordix/keycloak/common/ProviderConfig.java
+++ b/src/main/java/io/github/nordix/keycloak/common/ProviderConfig.java
@@ -27,6 +27,7 @@ public class ProviderConfig {
     private int kvVersion;
     private String caCertificateFile;
     private String role;
+    private String cacheName;
 
     public ProviderConfig(Scope configScope, String cmdLineOptionPrefix) {
         this.authMethod = configScope.get("auth-method", "kubernetes");
@@ -38,6 +39,7 @@ public class ProviderConfig {
         this.kvVersion = Integer.parseInt(configScope.get("kv-version", "1"));
         this.caCertificateFile = configScope.get("ca-certificate-file");
         this.role = configScope.get("role", "");
+        this.cacheName = configScope.get("cache-name");
 
         if (address == null) {
             logger.error(cmdLineOptionPrefix + "address + must be provided");
@@ -104,6 +106,10 @@ public class ProviderConfig {
         return role;
     }
 
+    public String getCacheName() {
+        return cacheName;
+    }
+
     @Override
     public String toString() {
         return "SecretsProviderConfig{" +
@@ -115,7 +121,7 @@ public class ProviderConfig {
                 ", kvVersion=" + kvVersion +
                 ", caCertificateFile='" + caCertificateFile + '\'' +
                 ", role='" + role + '\'' +
-                ", serviceAccountFile='" + serviceAccountFile + '\'' +
+                ", cacheName=" + (cacheName == null || cacheName.isEmpty() ? "<disabled>" : "'" + cacheName + "'") +
                 '}';
     }
 }

--- a/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProvider.java
+++ b/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProvider.java
@@ -18,6 +18,10 @@ import org.keycloak.vault.DefaultVaultRawSecret;
 import org.keycloak.vault.VaultProvider;
 import org.keycloak.vault.VaultRawSecret;
 
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.infinispan.Cache;
+
 import io.github.nordix.baoclient.BaoClient;
 import io.github.nordix.keycloak.common.ProviderConfig;
 
@@ -28,8 +32,9 @@ public class SecretsProvider implements VaultProvider {
     private final String realm;
     private final ProviderConfig config;
     private String pathPrefix;
+    private final Cache<String, String> secretsCache;
 
-    public SecretsProvider(String realm, ProviderConfig config) {
+    public SecretsProvider(String realm, ProviderConfig config, KeycloakSession session) {
         logger.debugv("Initializing SecretsProvider for realm {0} with config: {1}", realm, config);
         this.realm = realm;
         this.config = config;
@@ -39,6 +44,13 @@ public class SecretsProvider implements VaultProvider {
         // Remove trailing slash if present.
         if (pathPrefix.endsWith("/")) {
             pathPrefix = pathPrefix.substring(0, pathPrefix.length() - 1);
+        }
+
+        // Get the Infinispan cache for client secrets.
+        if (config.getCacheName() != null && !config.getCacheName().isEmpty()) {
+            this.secretsCache = session.getProvider(InfinispanConnectionProvider.class).getCache(config.getCacheName());
+        } else {
+            this.secretsCache = null;
         }
     }
 
@@ -53,26 +65,37 @@ public class SecretsProvider implements VaultProvider {
     }
 
     /**
-     * Retrieves a secret value from a Vault Key/Value (K/V) secrets engine using the provided secret identifier.
+     * Retrieves a secret value from OpenBao/HashiCorp Vault KV secrets engine using the provided secret identifier.
      * <p>
      * The {@code vaultSecretId} parameter should follow the syntax:
+     *
      * <pre>
      *   [path/to/secret]:[field]
      * </pre>
-     * if the field is not specified, it defaults to {@code secret}.
-     * The special token {@code %realm%} in the {@code vaultSecretId} will be replaced with the current realm.
-     * The prefix for the path is derived from the configuration's K/V path prefix, which is also replaced with the current realm.
      *
-     * @param vaultSecretId the identifier of the secret in the format {@code [path/to/secret].[field]}, with optional {@code %realm%} token
+     * If the field is not specified, it defaults to {@code secret}.
+     * The special token {@code %realm%} in the {@code vaultSecretId} will be replaced with the current realm.
+     * The prefix for the path is derived from the configuration's K/V path prefix, which is also replaced
+     * with the current realm.
+     *
+     * If caching is enabled, the secret value may be retrieved from Keycloak's Infinispan cache instead of
+     * fetching it from KV secrets engine.
+     * The cache key is the full path to the KV secrets engine and the value is the secret itself.
+     *
+     * @param vaultSecretId the identifier of the secret in the format
+     *                      {@code [path/to/secret].[field]}, with optional
+     *                      {@code %realm%} token
      * @return a {@link VaultRawSecret} containing the secret value as a byte buffer
-     * @throws IOException if an I/O error occurs during Vault communication
+     * @throws IOException              if an I/O error occurs during Vault
+     *                                  communication
      * @throws IllegalArgumentException if the configured KV version is unsupported
-     * @throws RuntimeException if the secret value is empty or cannot be retrieved
+     * @throws RuntimeException         if the secret value is empty or cannot be
+     *                                  retrieved
      */
     private VaultRawSecret obtainSecretInternal(String vaultSecretId) throws IOException {
-        String pathSuffix = vaultSecretId.replace("%realm%", realm);
-        String fieldName = null;
-        String fullPath = null;
+        final String pathSuffix = vaultSecretId.replace("%realm%", realm);
+        final String fieldName;
+        final String fullPath;
 
         int separatorIndex = pathSuffix.lastIndexOf(':');
         if (separatorIndex > 0) {
@@ -83,29 +106,36 @@ public class SecretsProvider implements VaultProvider {
             fieldName = "secret";
         }
 
-        logger.debugv("vaultSecretId={0} resolved to path={1} field={2}", vaultSecretId, fullPath, fieldName);
+        logger.debugv("vaultSecretId={0} resolved to path={1} field={2} {3}", vaultSecretId, fullPath, fieldName,
+                secretsCache != null ? "using cache" : "not using cache");
 
-        BaoClient client = new BaoClient(config.getAddress());
-
-        if (config.getCaCertificateFile() != null) {
-            client.withCaCertificateFile(config.getCaCertificateFile());
+        String secretValue;
+        if (secretsCache != null) {
+            // Note: this cache-population approach has a race condition:
+            //
+            // 1. Keycloak A checks the cache -> miss; fetches the secret from the server
+            // 2. Keycloak B checks the cache -> miss; also fetches the secret from the server
+            // 3. Keycloak A writes the secret into the cache
+            // 4. Keycloak B writes the secret into the cache
+            //
+            // The extra fetch performed by B is wasteful but acceptable here. The cache will end up
+            // containing the most recently stored value, which is fine for our use case.
+            //
+            // We could consider using secretsCache.computeIfAbsent(...) to avoid duplicate fetches.
+            // However, that may cause the fetch function to be executed by Infinispan on another node (?)
+            // This class, nor the attributes are not serializable which is required by computeIfAbsent().
+            // If making them serializable, it might have risks when software is updated and nodes run
+            // different versions of the class?
+            //
+            // For having well understood behavior, just we use simple get/put intead.
+            secretValue = secretsCache.get(fullPath);
+            if (secretValue == null) {
+                secretValue = fetchSecretFromServer(fullPath, fieldName);
+                secretsCache.put(fullPath, secretValue);
+            }
+        } else {
+            secretValue = fetchSecretFromServer(fullPath, fieldName);
         }
-
-        client.loginWithKubernetes(config.getServiceAccountFile(), config.getRole());
-
-        Map<String, String> secretValues;
-        switch (config.getKvVersion()) {
-            case 1:
-                secretValues = client.kv1Get(config.getKvMount(), fullPath);
-                break;
-            case 2:
-                secretValues = client.kv2Get(config.getKvMount(), fullPath);
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported kv-version: " + config.getKvVersion());
-        }
-
-        String secretValue = secretValues.get(fieldName);
 
         if (secretValue == null || secretValue.isEmpty()) {
             logger.errorv("Secret value for path {0} and field {1} is empty", fullPath, fieldName);
@@ -113,6 +143,26 @@ public class SecretsProvider implements VaultProvider {
         }
 
         return DefaultVaultRawSecret.forBuffer(Optional.of(ByteBuffer.wrap(secretValue.getBytes())));
+    }
+
+    private String fetchSecretFromServer(String fullPath, String fieldName) {
+        BaoClient client = new BaoClient(config.getAddress());
+
+        if (config.getCaCertificateFile() != null) {
+            client.withCaCertificateFile(config.getCaCertificateFile());
+        }
+
+        try {
+            client.loginWithKubernetes(config.getServiceAccountFile(), config.getRole());
+        } catch (IOException e) {
+            logger.errorv("IOException while logging in to Kubernetes for path {0} and field {1}", fullPath, fieldName,
+                    e);
+            throw new RuntimeException("IOException while logging in to Kubernetes", e);
+        }
+
+        Map<String, String> secretValues = client.kv1Get(config.getKvMount(), fullPath);
+
+        return secretValues.get(fieldName);
     }
 
     @Override

--- a/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProviderFactory.java
+++ b/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProviderFactory.java
@@ -40,7 +40,7 @@ public class SecretsProviderFactory implements VaultProviderFactory {
 
     @Override
     public VaultProvider create(KeycloakSession session) {
-        return new SecretsProvider(session.getContext().getRealm().getName(), config);
+        return new SecretsProvider(session.getContext().getRealm().getName(), config, session);
     }
 
     @Override

--- a/src/test/java/io/github/nordix/junit/Metrics.java
+++ b/src/test/java/io/github/nordix/junit/Metrics.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2025 OpenInfra Foundation Europe and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.nordix.junit;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Fetch and assert metrics from a Prometheus-compatible metrics endpoint.
+ */
+public class Metrics {
+
+    private final URI metricsUrl;
+
+    private Map<String, String> baselineMetrics = new HashMap<>();
+
+    public Metrics(String metricsUrl) {
+        this.metricsUrl = URI.create(metricsUrl);
+        resetMetrics();
+    }
+
+    public void resetMetrics() {
+        baselineMetrics = fetchMetrics();
+    }
+
+    public void assertCounterIncrementedBy(String metricName, int expectedStep) throws AssertionError {
+        Map<String, String> currentMetrics = fetchMetrics();
+
+        // If OpenBao was just started, the desired metric might not exist yet.
+        // In such cases, default to using "0" as the metric value.
+        int baselineValue = Integer.parseInt(baselineMetrics.getOrDefault(metricName, "0"));
+        int currentValue = Integer.parseInt(currentMetrics.getOrDefault(metricName, "0"));
+        int actualStep = currentValue - baselineValue;
+        if (actualStep != expectedStep) {
+            throw new AssertionError(String.format("Expected metric '%s' to step by %d, but was %d", metricName,
+                    expectedStep, actualStep));
+        }
+    }
+
+    private Map<String, String> fetchMetrics() {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(metricsUrl)
+                .GET()
+                .build();
+
+        HttpResponse<Map<String, String>> send;
+        try {
+            send = client.send(request, prometheusFormatBodyHandler());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to fetch metrics", e);
+        }
+
+        if (send.statusCode() / 100 != 2) {
+            throw new RuntimeException("Failed to fetch metrics (HTTP status code: " + send.statusCode() + ")");
+        }
+
+        return send.body();
+    }
+
+    private static BodyHandler<Map<String, String>> prometheusFormatBodyHandler() {
+        return respInfo -> BodySubscribers.mapping(
+                BodySubscribers.ofString(StandardCharsets.UTF_8),
+                body -> {
+                    Map<String, String> result = new HashMap<>();
+                    for (String line : body.split("\n")) {
+                        line = line.trim();
+
+                        // Skip comment lines.
+                        if (line.isEmpty() || line.startsWith("#"))
+                            continue;
+
+                        // Split line into name and value.
+                        int spaceIdx = line.indexOf(' ');
+                        String name = spaceIdx > 0 ? line.substring(0, spaceIdx) : line;
+                        String value = spaceIdx > 0 ? line.substring(spaceIdx + 1) : "<no value>";
+                        result.put(name, value);
+                    }
+                    return result;
+                });
+    }
+
+}

--- a/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
@@ -9,24 +9,22 @@
 
 package io.github.nordix.keycloak.services.secretsmanager;
 
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+
 import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import io.github.nordix.junit.KeycloakRestClientExtension;
 import io.github.nordix.junit.LoggingExtension;
-import org.junit.jupiter.api.Assertions;
-
-import java.net.http.HttpResponse;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 @ExtendWith(LoggingExtension.class)
 class SecretsManagerIT {
@@ -40,7 +38,8 @@ class SecretsManagerIT {
     private final SecretsCleanupExtension secretsCleanup = new SecretsCleanupExtension();
 
     @RegisterExtension
-    private final KeycloakRestClientExtension keycloakAdminClient = new KeycloakRestClientExtension(KEYCLOAK_BASE_URL);
+    private final KeycloakRestClientExtension keycloakAdminClient = new KeycloakRestClientExtension(
+            KEYCLOAK_BASE_URL);
 
     private static final String REALM = "first";
     private static final String API_PATH = "/admin/realms/" + REALM + "/secrets-manager";
@@ -238,7 +237,8 @@ class SecretsManagerIT {
         Assertions.assertEquals(405, postResp.statusCode(), "POST should not be allowed");
 
         HttpResponse<JsonNode> patchResp = keycloakAdminClient
-                .sendRequest(API_PATH + "/invalid-update-with-patch", "PATCH", Map.of("secret", "value"));
+                .sendRequest(API_PATH + "/invalid-update-with-patch", "PATCH",
+                        Map.of("secret", "value"));
         Assertions.assertEquals(405, patchResp.statusCode(), "PATCH should not be allowed");
     }
 
@@ -252,9 +252,12 @@ class SecretsManagerIT {
                     if (idsNode != null && idsNode.isArray()) {
                         for (JsonNode idNode : idsNode) {
                             String id = idNode.asText();
-                            HttpResponse<JsonNode> delResp = keycloakAdminClient.sendRequest(API_PATH + "/" + id, "DELETE");
-                            if (delResp.statusCode() != 204 && delResp.statusCode() != 404) {
-                                logger.warnv("Failed to delete secret {0}, status: {1}", id, delResp.statusCode());
+                            HttpResponse<JsonNode> delResp = keycloakAdminClient
+                                    .sendRequest(API_PATH + "/" + id, "DELETE");
+                            if (delResp.statusCode() != 204
+                                    && delResp.statusCode() != 404) {
+                                logger.warnv("Failed to delete secret {0}, status: {1}",
+                                        id, delResp.statusCode());
                             }
                         }
                     }

--- a/src/test/java/io/github/nordix/keycloak/services/vault/SecretsProviderIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/vault/SecretsProviderIT.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -25,13 +26,14 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.github.nordix.junit.KeycloakRestClientExtension;
 import io.github.nordix.junit.LoggingExtension;
+import io.github.nordix.junit.Metrics;
 
 @ExtendWith(LoggingExtension.class)
 class SecretsProviderIT {
@@ -46,50 +48,152 @@ class SecretsProviderIT {
         UNHANDLED_RESULT
     }
 
-    private static final String KEYCLOAK_BASE_URL = "http://127.0.0.127:8080";
+    private static final String KEYCLOAK_0_BASE_URL = "http://127.0.0.127:8080";
+    private static final String KEYCLOAK_1_BASE_URL = "http://127.0.0.127:8081";
     private static final String PROVIDER_REALM = "provider-realm";
     private static final String CONSUMER_REALM = "consumer-realm";
     private static final String PROVIDER_CLIENT_NAME = "federator";
     private static final String PROVIDER_CLIENT_SECRET = "my-secret";
     private static final String USER_LOGIN = "joe";
     private static final String USER_PASSWORD = "password";
+    private static final String OPENBAO_BASE_URL = "http://127.0.0.127:8200";
+    private static final String OPENBAO_METRICS_URL = OPENBAO_BASE_URL + "/v1/sys/metrics?format=prometheus";
 
     // Keycloak client extension to interact with Keycloak admin API.
     @RegisterExtension
-    private static final KeycloakRestClientExtension keycloakAdminClient = new KeycloakRestClientExtension(
-            KEYCLOAK_BASE_URL);
+    private static final KeycloakRestClientExtension keycloak0AdminClient = new KeycloakRestClientExtension(
+            KEYCLOAK_0_BASE_URL);
 
     @RegisterExtension
-    private final SetupFederatedRealms realms = new SetupFederatedRealms();
+    private static final KeycloakRestClientExtension keycloak1AdminClient = new KeycloakRestClientExtension(
+            KEYCLOAK_1_BASE_URL);
+
+    @RegisterExtension
+    private final IdentityProviderdRealm providerRealm = new IdentityProviderdRealm();
+
+    @RegisterExtension
+    private final IdentityConsumerRealm consumerRealm = new IdentityConsumerRealm();
 
     @Test
     void testSecretReference() {
-        realms.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
-        realms.setSecretReference("${vault.idp.federator}");
+        consumerRealm.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
+        consumerRealm.setIdentityBrokeringConfig("${vault.idp.federator}");
+
         AuthenticationResult result = performBrowserLogin(USER_LOGIN, USER_PASSWORD);
         Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
-            "Expected successful login when valid vault secret reference is used");
+                "Expected successful login when valid vault secret reference is used");
     }
 
     @Test
     void testInvalidSecretReference() {
-        realms.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
-        realms.setSecretReference("${vault.idp.invalid}");
+        consumerRealm.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
+        consumerRealm.setIdentityBrokeringConfig("${vault.idp.invalid}");
+
         AuthenticationResult result = performBrowserLogin(USER_LOGIN, USER_PASSWORD);
         Assertions.assertEquals(AuthenticationResult.UNEXPECTED_ERROR, result,
-            "Expected invalid vault reference error when non-existent secret is referenced");
+                "Expected invalid vault reference error when non-existent secret is referenced");
     }
 
     @Test
     void testInvalidCredentials() {
-        realms.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
-        realms.setSecretReference("${vault.idp.federator}");
+        consumerRealm.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
+        consumerRealm.setIdentityBrokeringConfig("${vault.idp.federator}");
+
         AuthenticationResult result = performBrowserLogin("invalid-user", "wrong-password");
         Assertions.assertEquals(AuthenticationResult.INVALID_LOGIN, result,
-            "Expected invalid credentials error when wrong username/password is used");
+                "Expected invalid credentials error when wrong username/password is used");
     }
 
-    private AuthenticationResult performBrowserLogin(String username, String password) {
+    @Test
+    void testSecretCacheDistributedHit() {
+        consumerRealm.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
+        consumerRealm.setIdentityBrokeringConfig("${vault.idp.federator}");
+
+        Metrics metrics = new Metrics(OPENBAO_METRICS_URL);
+
+        // Login to consumer realm using Keycloak 0.
+        AuthenticationResult result = performBrowserLogin(KEYCLOAK_0_BASE_URL, USER_LOGIN, USER_PASSWORD);
+        Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
+                "Expected successful login when valid vault secret reference is used");
+
+        // Login to consumer realm using Keycloak 1.
+        AuthenticationResult result1 = performBrowserLogin(KEYCLOAK_1_BASE_URL, USER_LOGIN, USER_PASSWORD);
+        Assertions.assertEquals(AuthenticationResult.SUCCESS, result1,
+                "Expected successful login when valid vault secret reference is used");
+
+        // Check that the secret was only fetched once by Keycloak 0 and Keycloak 1 accessed it from the cache.
+        metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 1);
+    }
+
+    @Test
+    void testSecretCacheDistributedInvalidation() {
+        consumerRealm.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
+        consumerRealm.setIdentityBrokeringConfig("${vault.idp.federator}");
+
+        Metrics metrics = new Metrics(OPENBAO_METRICS_URL);
+
+        AuthenticationResult result = performBrowserLogin(KEYCLOAK_0_BASE_URL, USER_LOGIN, USER_PASSWORD);
+        Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
+                "Expected successful login when valid vault secret reference is used");
+
+        // Update the secret in OpenBao using Keycloak 0. This also evicts the old secret from the distributed cache.
+        String newSecret = "my-new-secret";
+        consumerRealm.storeSecret("idp.federator", newSecret);
+        providerRealm.updateClientSecret(newSecret);
+
+        // Login into consumer realm using Keycloak 1.
+        result = performBrowserLogin(KEYCLOAK_1_BASE_URL, USER_LOGIN, USER_PASSWORD);
+        Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
+                "Expected successful login when updated vault secret reference is used");
+
+        // Two reads from OpenBao: one from Keycloak 0 and one from Keycloak 1 after the update.
+        metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 2);
+    }
+
+
+    /**
+     * Test case for verifying secret cache expiry.
+     *
+     * NOTE:
+     * To run this test case, change the expiration manually in custom-cache-ispn.xml to
+     *     <expiration lifespan="5000"/>
+     * and restart Keycloak.
+     */
+    @Disabled("Disabled due to manual cache expiration configuration update requirement.")
+    @Test
+    void testSecretCacheExpiry() throws InterruptedException {
+        consumerRealm.storeSecret("idp.federator", PROVIDER_CLIENT_SECRET);
+        consumerRealm.setIdentityBrokeringConfig("${vault.idp.federator}");
+
+        Metrics metrics = new Metrics(OPENBAO_METRICS_URL);
+
+        // Login to consumer realm (cache miss).
+        AuthenticationResult result = performBrowserLogin(KEYCLOAK_0_BASE_URL, USER_LOGIN, USER_PASSWORD);
+        Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
+                "Expected successful login when valid vault secret reference is used");
+
+        // Login to consumer realm again (cache hit).
+        result = performBrowserLogin(KEYCLOAK_0_BASE_URL, USER_LOGIN, USER_PASSWORD);
+        Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
+                "Expected successful login when valid vault secret reference is used");
+
+        // Wait for the cache entry to expire.
+        Thread.sleep(6000);
+
+        // Login to consumer realm after cache expiry (cache miss).
+        result = performBrowserLogin(KEYCLOAK_0_BASE_URL, USER_LOGIN, USER_PASSWORD);
+        Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
+                "Expected successful login when valid vault secret reference is used");
+
+        // Check that the secret was fetched 2 times (2 cache misses).
+        metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 2);
+    }
+
+    AuthenticationResult performBrowserLogin(String username, String password) {
+        return performBrowserLogin(KEYCLOAK_0_BASE_URL, username, password);
+    }
+
+    AuthenticationResult performBrowserLogin(String baseUrl, String username, String password) {
         ChromeOptions options = new ChromeOptions();
         // Comment out headless if want to see browser for debugging.
         options.addArguments("--headless");
@@ -97,8 +201,10 @@ class SecretsProviderIT {
         WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 
         try {
-            String consumerLoginUrl = KEYCLOAK_BASE_URL + "/realms/" + CONSUMER_REALM + "/protocol/openid-connect/auth"
-                    + "?client_id=account&redirect_uri=" + KEYCLOAK_BASE_URL + "/realms/" + CONSUMER_REALM + "/account/"
+            String consumerLoginUrl = baseUrl + "/realms/" + CONSUMER_REALM
+                    + "/protocol/openid-connect/auth"
+                    + "?client_id=account&redirect_uri=" + baseUrl + "/realms/" + CONSUMER_REALM
+                    + "/account/"
                     + "&response_type=code&scope=openid";
             logger.debug("Navigating to consumer login URL: " + consumerLoginUrl);
             driver.get(consumerLoginUrl);
@@ -129,83 +235,84 @@ class SecretsProviderIT {
             logger.debug(driver.getPageSource());
             return AuthenticationResult.WEBDRIVER_EXCEPTION;
         } finally {
+            // Comment out the following line if you want to keep the browser open for debugging.
             driver.quit();
         }
 
         return AuthenticationResult.UNHANDLED_RESULT;
     }
 
-    class SetupFederatedRealms implements BeforeEachCallback, AfterEachCallback {
+    class IdentityProviderdRealm implements BeforeEachCallback, AfterEachCallback {
 
         @Override
         public void beforeEach(ExtensionContext context) throws Exception {
-            logger.info("Creating realm: " + PROVIDER_REALM);
-            HttpResponse<JsonNode> resp = keycloakAdminClient.sendRequest("/admin/realms", "POST", Map.of(
-                    "realm", PROVIDER_REALM,
-                    "enabled", true));
-            Assertions.assertEquals(201, resp.statusCode(), "Failed to create provider realm: + " + resp.body());
+            keycloak0AdminClient.createRealm(PROVIDER_REALM);
 
-            logger.info("Creating realm: " + CONSUMER_REALM);
-            resp = keycloakAdminClient.sendRequest("/admin/realms", "POST", Map.of(
-                    "realm", CONSUMER_REALM,
-                    "enabled", true));
-            Assertions.assertEquals(201, resp.statusCode(), "Failed to create consumer realm: + " + resp.body());
+            // Create client in provider realm for identity brokering tests.
+            // This client will have cleartext secret and federated consumer realm will be
+            // used to test vault references.
+            keycloak0AdminClient.createClient(PROVIDER_REALM, PROVIDER_CLIENT_NAME,
+                    PROVIDER_CLIENT_SECRET, List.of(KEYCLOAK_0_BASE_URL, KEYCLOAK_1_BASE_URL));
 
-            // Create client in provider realm.
-            // This client will have cleartext secret.
-            // Consumer realm will be used to test vault reference.
-            logger.info("Creating client: " + PROVIDER_CLIENT_NAME + " in realm: " + PROVIDER_REALM);
-            keycloakAdminClient.sendRequest("/admin/realms/" + PROVIDER_REALM + "/clients", "POST", Map.of(
-                    "clientId", PROVIDER_CLIENT_NAME,
-                    "enabled", true,
-                    "protocol", "openid-connect",
-                    "publicClient", false,
-                    "serviceAccountsEnabled", true,
-                    "redirectUris", List.of(KEYCLOAK_BASE_URL + "/*"),
-                    "webOrigins", List.of(KEYCLOAK_BASE_URL + "/*"),
-                    "secret", PROVIDER_CLIENT_SECRET));
+            // Create user in provider realm for identity brokering tests.
+            keycloak0AdminClient.createUser(PROVIDER_REALM, USER_LOGIN, USER_PASSWORD);
 
-            // Create user in provider realm.
-            logger.info("Creating user: " + USER_LOGIN + " in realm: " + PROVIDER_REALM);
-            keycloakAdminClient.sendRequest("/admin/realms/" + PROVIDER_REALM + "/users", "POST", Map.of(
-                    "username", USER_LOGIN,
-                    "enabled", true,
-                    "email", "email@example.com",
-                    "firstName", "First",
-                    "lastName", "Last",
-                    "credentials", List.of(Map.of(
-                            "type", "password",
-                            "value", USER_PASSWORD,
-                            "temporary", false))));
+        }
 
-            // Create identity provider in consumer realm.
-            // Test case will use this to check that vault secret is fetched correctly.
-            logger.info("Creating identity provider in realm: " + CONSUMER_REALM);
-            keycloakAdminClient.sendRequest("/admin/realms/" + CONSUMER_REALM + "/identity-provider/instances", "POST",
+        public void updateClientSecret(String newSecret) {
+            keycloak0AdminClient.updateClientAttribute(PROVIDER_REALM, PROVIDER_CLIENT_NAME, "secret", newSecret);
+        }
+
+        @Override
+        public void afterEach(ExtensionContext context) throws Exception {
+            keycloak0AdminClient.deleteRealm(PROVIDER_REALM);
+        }
+    }
+
+    class IdentityConsumerRealm implements BeforeEachCallback, AfterEachCallback {
+
+        @Override
+        public void beforeEach(ExtensionContext context) throws Exception {
+            keycloak0AdminClient.createRealm(CONSUMER_REALM);
+        }
+
+        void setIdentityBrokeringConfig(String secret) {
+            logger.info("Configuring identity provider in realm: " + CONSUMER_REALM);
+            keycloak0AdminClient.sendRequest("/admin/realms/" + CONSUMER_REALM + "/identity-provider/instances", "POST",
                     Map.of(
                             "alias", "federator",
                             "providerId", "keycloak-oidc",
                             "config", Map.of(
                                     "clientId", PROVIDER_CLIENT_NAME,
-                                    "clientSecret", "<placeholder>",
+                                    "clientSecret", secret,
                                     "authorizationUrl",
-                                    KEYCLOAK_BASE_URL + "/realms/provider-realm/protocol/openid-connect/auth",
+                                    KEYCLOAK_0_BASE_URL + "/realms/provider-realm/protocol/openid-connect/auth",
                                     "tokenUrl",
-                                    KEYCLOAK_BASE_URL + "/realms/provider-realm/protocol/openid-connect/token")));
+                                    KEYCLOAK_0_BASE_URL + "/realms/provider-realm/protocol/openid-connect/token")));
+
+        }
+
+        void storeSecret(String secretName, String secretValue) {
+            logger.debugv("Storing secret {0} with value {1} in realm {2}", secretName, secretValue, CONSUMER_REALM);
+            HttpResponse<JsonNode> response = keycloak0AdminClient.sendRequest(
+                    "/admin/realms/" + CONSUMER_REALM + "/secrets-manager/" + secretName, "PUT",
+                    Map.of("secret", secretValue));
+            Assertions.assertEquals(200, response.statusCode(), "Failed to create secret");
         }
 
         @Override
         public void afterEach(ExtensionContext context) throws Exception {
-            // Clean up secrets in the consumer realm. before delete.
+            // Clean up secrets before deleting the realm (otherwise they will be left orphaned in OpenBao).
+            logger.info("Cleaning up secrets for realm: " + CONSUMER_REALM);
             try {
-                HttpResponse<JsonNode> listResp = keycloakAdminClient
+                HttpResponse<JsonNode> listResp = keycloak0AdminClient
                         .sendRequest("/admin/realms/" + CONSUMER_REALM + "/secrets-manager", "GET");
                 if (listResp.statusCode() == 200) {
                     JsonNode idsNode = listResp.body().get("secret_ids");
                     if (idsNode != null && idsNode.isArray()) {
                         for (JsonNode idNode : idsNode) {
                             String id = idNode.asText();
-                            HttpResponse<JsonNode> delResp = keycloakAdminClient.sendRequest(
+                            HttpResponse<JsonNode> delResp = keycloak0AdminClient.sendRequest(
                                     "/admin/realms/" + CONSUMER_REALM + "/secrets-manager/" + id, "DELETE");
                             if (delResp.statusCode() != 204 && delResp.statusCode() != 404) {
                                 logger.warnv("Failed to delete secret {0}, status: {1}", id, delResp.statusCode());
@@ -214,39 +321,11 @@ class SecretsProviderIT {
                     }
                 }
             } catch (Exception e) {
+                // Log the exception
                 logger.warnv(e, "Exception during secrets cleanup");
             }
 
-            // Delete realms.
-            keycloakAdminClient.sendRequest("/admin/realms/" + PROVIDER_REALM, "DELETE");
-            keycloakAdminClient.sendRequest("/admin/realms/" + CONSUMER_REALM, "DELETE");
+            keycloak0AdminClient.deleteRealm(CONSUMER_REALM);
         }
-
-        void storeSecret(String secretName, String secretValue) {
-            logger.debugv("Storing secret {0} with value {1} in realm {2}", secretName, secretValue, CONSUMER_REALM);
-            HttpResponse<JsonNode> response = keycloakAdminClient.sendRequest(
-                    "/admin/realms/" + CONSUMER_REALM + "/secrets-manager/" + secretName, "PUT",
-                    Map.of("secret", secretValue));
-            Assertions.assertEquals(200, response.statusCode(), "Failed to create secret");
-        }
-
-        void setSecretReference(String secret) {
-            HttpResponse<JsonNode> response = keycloakAdminClient.sendRequest(
-                    "/admin/realms/" + CONSUMER_REALM + "/identity-provider/instances/federator",
-                    "PUT",
-                    Map.of(
-                            "alias", "federator",
-                            "providerId", "keycloak-oidc",
-                            "config", Map.of(
-                                    "clientId", PROVIDER_CLIENT_NAME,
-                                    "clientSecret", secret,
-                                    "authorizationUrl",
-                                    KEYCLOAK_BASE_URL + "/realms/provider-realm/protocol/openid-connect/auth",
-                                    "tokenUrl",
-                                    KEYCLOAK_BASE_URL + "/realms/provider-realm/protocol/openid-connect/token")));
-            Assertions.assertEquals(204, response.statusCode(), "Failed to update identity provider config");
-        }
-
     }
-
 }

--- a/testing/configs/custom-cache-ispn.xml
+++ b/testing/configs/custom-cache-ispn.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:15.0 http://www.infinispan.org/schemas/infinispan-config-15.0.xsd"
+        xmlns="urn:infinispan:config:15.0">
+
+    <cache-container name="keycloak">
+        <transport lock-timeout="60000"/>
+        <local-cache name="realms" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <local-cache name="users" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <distributed-cache name="sessions" owners="1">
+            <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
+        </distributed-cache>
+        <distributed-cache name="authenticationSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="offlineSessions" owners="1">
+            <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
+        </distributed-cache>
+        <distributed-cache name="clientSessions" owners="1">
+            <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
+        </distributed-cache>
+        <distributed-cache name="offlineClientSessions" owners="1">
+            <expiration lifespan="-1"/>
+            <memory max-count="10000"/>
+        </distributed-cache>
+        <distributed-cache name="loginFailures" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <local-cache name="authorization" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <replicated-cache name="work">
+            <expiration lifespan="-1"/>
+        </replicated-cache>
+        <local-cache name="keys" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="3600000"/>
+            <memory max-count="1000"/>
+        </local-cache>
+        <local-cache name="crl" simple-cache="true">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration lifespan="-1"/>
+            <memory max-count="1000"/>
+        </local-cache>
+        <distributed-cache name="actionTokens" owners="2">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+            <memory max-count="-1"/>
+        </distributed-cache>
+        <replicated-cache name="vaultExtensionSecrets">
+            <encoding>
+                <key media-type="text/plain; charset=UTF-8"/>
+                <value media-type="text/plain; charset=UTF-8"/>
+            </encoding>
+            <expiration lifespan="-1"/>
+            <memory max-count="1000"/>
+        </replicated-cache>
+    </cache-container>
+</infinispan>

--- a/testing/configs/kind-cluster-config.yaml
+++ b/testing/configs/kind-cluster-config.yaml
@@ -13,11 +13,17 @@ kubeadmConfigPatches:
 nodes:
 - role: control-plane
   extraPortMappings:
+  # OpenBao HTTP
   - containerPort: 8200
     hostPort: 8200
     listenAddress: "127.0.0.127"
+  # Keycloak-0 HTTP
   - containerPort: 8080
     hostPort: 8080
+    listenAddress: "127.0.0.127"
+  # Keycloak-1 HTTP
+  - containerPort: 8081
+    hostPort: 8081
     listenAddress: "127.0.0.127"
   extraMounts:
    - hostPath: ./

--- a/testing/manifests/keycloak.yaml
+++ b/testing/manifests/keycloak.yaml
@@ -1,15 +1,29 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: keycloak
+  name: keycloak-0
 spec:
   selector:
-    app: keycloak
+    statefulset.kubernetes.io/pod-name: keycloak-0
   ports:
     - protocol: TCP
       port: 8080
       targetPort: 8080
       nodePort: 8080
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-1
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: keycloak-1
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      nodePort: 8081
   type: NodePort
 ---
 apiVersion: v1
@@ -38,7 +52,7 @@ spec:
   selector:
     matchLabels:
       app: keycloak
-  replicas: 1
+  replicas: 2
   serviceName: keycloak-headless
   template:
     metadata:
@@ -55,21 +69,25 @@ spec:
               cp /host/target/secrets-provider-*jar /opt/keycloak/providers/secrets-provider.jar
               mkdir -p /opt/keycloak/data/import
               cp /host/testing/configs/keycloak-realms/* /opt/keycloak/data/import/
-              /opt/keycloak/bin/kc.sh start-dev \
+              cp /host/testing/configs/custom-cache-ispn.xml /opt/keycloak/conf/custom-cache-ispn.xml
+              /opt/keycloak/bin/kc.sh start \
                 --import-realm \
                 --spi-vault-provider=secrets-provider \
-                --spi-vault-secrets-provider-address=https://openbao:8200 \
+                --spi-vault-secrets-provider-address=https://openbao:18200 \
                 --spi-vault-secrets-provider-ca-certificate-file=/host/testing/certs/ca.pem \
                 --spi-vault-secrets-provider-kv-mount=secretv1 \
                 --spi-vault-secrets-provider-kv-path-prefix="keycloak/%realm%" \
                 --spi-vault-secrets-provider-kv-version=1 \
                 --spi-vault-secrets-provider-role=keycloak-reader \
-                --spi-admin-realm-restapi-extension-secrets-manager-address=https://openbao:8200 \
+                --spi-vault-secrets-provider-cache-name=vaultExtensionSecrets \
+                --spi-admin-realm-restapi-extension-secrets-manager-address=https://openbao:18200 \
                 --spi-admin-realm-restapi-extension-secrets-manager-ca-certificate-file=/host/testing/certs/ca.pem \
                 --spi-admin-realm-restapi-extension-secrets-manager-kv-mount=secretv1 \
                 --spi-admin-realm-restapi-extension-secrets-manager-kv-path-prefix="keycloak/%realm%" \
                 --spi-admin-realm-restapi-extension-secrets-manager-kv-version=1 \
                 --spi-admin-realm-restapi-extension-secrets-manager-role=keycloak-admin \
+                --spi-admin-realm-restapi-extension-secrets-manager-cache-name=vaultExtensionSecrets \
+                --cache-config-file=custom-cache-ispn.xml \
                 --log-level=INFO,io.github.nordix:debug
           env:
             - name: KC_BOOTSTRAP_ADMIN_USERNAME
@@ -80,6 +98,16 @@ spec:
               value: "true"
             - name: KC_HEALTH_ENABLED
               value: "true"
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            - name: KC_DB
+              value: "postgres"
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://postgres/keycloak"
+            - name: KC_DB_USERNAME
+              value: "keycloak"
+            - name: KC_DB_PASSWORD
+              value: "keycloak"
 
           ports:
             - name: http

--- a/testing/manifests/openbao.yaml
+++ b/testing/manifests/openbao.yaml
@@ -25,10 +25,15 @@ spec:
   selector:
     app: openbao
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 8200
-      targetPort: 8200
+      targetPort: http
       nodePort: 8200
+    - name: https
+      protocol: TCP
+      port: 18200
+      targetPort: https
   type: NodePort
 ---
 apiVersion: apps/v1
@@ -58,7 +63,12 @@ spec:
             - name: BAO_LOG_LEVEL
               value: "debug"
           ports:
-            - containerPort: 8200
+            - name: http
+              containerPort: 8200
+              protocol: TCP
+            - name: https
+              containerPort: 18200
+              protocol: TCP
           volumeMounts:
             - name: openbao-config
               mountPath: /config
@@ -90,9 +100,7 @@ spec:
             - /config/initialize.sh
           env:
             - name: BAO_ADDR
-              value: "https://localhost:8200"
-            - name: BAO_CACERT
-              value: "/host/testing/certs/ca.pem"
+              value: "http://localhost:8200"
           volumeMounts:
             - name: openbao-config
               mountPath: /config
@@ -101,7 +109,6 @@ spec:
               readOnly: true
             - name: unseal
               mountPath: /unseal
-
 
       serviceAccountName: tokenreview
 
@@ -176,9 +183,17 @@ data:
   openbao.json: |
     {
       "api_addr": "https://openbao:8200",
+      "ui": true,
       "listener": {
         "tcp": {
           "address": "0.0.0.0:8200",
+          "tls_disable": true,
+          "telemetry": {
+            "unauthenticated_metrics_access": true
+          }
+        },
+        "tcp": {
+          "address": "0.0.0.0:18200",
           "tls_cert_file": "/host/testing/certs/openbao.pem",
           "tls_key_file": "/host/testing/certs/openbao-key.pem",
           "tls_ca_file": "/host/testing/certs/ca.pem"
@@ -188,5 +203,10 @@ data:
         "file": {
           "path": "/tmp"
         }
+      },
+      "telemetry": {
+        "prefix_filter": [ "+vault" ]
+        "prometheus_retention_time": "1h",
+        "disable_hostname": true,
       }
     }

--- a/testing/manifests/postgresql.yaml
+++ b/testing/manifests/postgresql.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          env:
+            - name: POSTGRES_USER
+              value: "keycloak"
+            - name: POSTGRES_PASSWORD
+              value: "keycloak"
+            - name: POSTGRES_DB
+              value: "keycloak"
+            - name: POSTGRES_LOG_STATEMENT
+              value: "all"
+          ports:
+            - name: postgres
+              containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
Added optional caching with Infinispan to prevent redundant connections to OpenBao/Vault when the same secret is requested multiple times.

The cache name is configured via `--spi-vault-secrets-provider-cache-name` and `--spi-admin-realm-restapi-extension-secrets-manager-cache-name`. Users must define the cache in their custom Infinispan cache configuration file.

When a secret is updated or deleted through the Secrets Manager REST API, the Secrets Manager evicts it from the cache. The next access will then attempt to retrieve the secret again from OpenBao/Vault.

Fixes #19