### PR TITLE
remove jacoco coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,26 +218,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Jacoco coverage report -->
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${version.maven.jacoco.plugin}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>test</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <!-- Generate OpenAPI description -->
       <!-- config example from https://github.com/smallrye/smallrye-open-api/discussions/1353 -->
       <plugin>

--- a/src/test/java/io/github/nordix/keycloak/services/vault/SecretsProviderIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/vault/SecretsProviderIT.java
@@ -149,7 +149,7 @@ class SecretsProviderIT {
         Assertions.assertEquals(AuthenticationResult.SUCCESS, result,
                 "Expected successful login when updated vault secret reference is used");
 
-        // Two reads from OpenBao: one from Keycloak 0 and one from Keycloak 1 after the update.
+        // Check that there was two reads from OpenBao: one from Keycloak 0 and one from Keycloak 1 after the update.
         metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 2);
     }
 


### PR DESCRIPTION
The project has just integration tests (no unit tests) and we cannot get coverage reports from those. The code under test is loaded by Keycloak and does not run with the JVM executing tests.