### PR TITLE
Added tests and docs for secret field references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,7 @@ The access information for test environments is as follows:
 
   Admin credentials: `admin` / `admin`
 
-- Federated realm login: http://127.0.0.127:8080/realms/first/account/
-
-  User in "second" realm: `joe` / `joe`
+- Identity brokering has been pre-configured to Keycloak deployment for interactive testing. You can access the federated login at realm `first`: http://127.0.0.127:8080/realms/first/account/ and log in as user in `second` realm with credentials `joe` / `joe`
 
 
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -81,7 +81,7 @@
         "description" : "Creates a new secret or updates an existing secret. If a secret value is not provided in the request body, a random secret will be generated.",
         "tags" : [ "Secrets Manager" ],
         "parameters" : [ {
-          "description" : "ID of the secret to update. Must match the regex ^[a-zA-Z0-9_\\.-]+$ and must exist.",
+          "description" : "ID of the secret to update. Must match the regex ^[a-zA-Z0-9_.-]+$ and must exist.",
           "required" : true,
           "name" : "id",
           "in" : "path",
@@ -124,7 +124,7 @@
         "description" : "Retrieves a secret by its ID.",
         "tags" : [ "Secrets Manager" ],
         "parameters" : [ {
-          "description" : "ID of the secret to retrieve. Must match the regex ^[a-zA-Z0-9_\\.-]+$ and must exist.",
+          "description" : "ID of the secret to retrieve. Must match the regex ^[a-zA-Z0-9_.-]+$ and must exist.",
           "required" : true,
           "name" : "id",
           "in" : "path",
@@ -159,7 +159,7 @@
         "description" : "Deletes a secret by its ID.",
         "tags" : [ "Secrets Manager" ],
         "parameters" : [ {
-          "description" : "ID of the secret to delete. Must match the regex ^[a-zA-Z0-9_\\.-]+$ and must exist.",
+          "description" : "ID of the secret to delete. Must match the regex ^[a-zA-Z0-9_.-]+$ and must exist.",
           "required" : true,
           "name" : "id",
           "in" : "path",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -71,8 +71,8 @@ paths:
       tags:
       - Secrets Manager
       parameters:
-      - description: "ID of the secret to update. Must match the regex ^[a-zA-Z0-9_\\\
-          .-]+$ and must exist."
+      - description: "ID of the secret to update. Must match the regex ^[a-zA-Z0-9_.-]+$\
+          \ and must exist."
         required: true
         name: id
         in: path
@@ -103,8 +103,8 @@ paths:
       tags:
       - Secrets Manager
       parameters:
-      - description: "ID of the secret to retrieve. Must match the regex ^[a-zA-Z0-9_\\\
-          .-]+$ and must exist."
+      - description: "ID of the secret to retrieve. Must match the regex ^[a-zA-Z0-9_.-]+$\
+          \ and must exist."
         required: true
         name: id
         in: path
@@ -129,8 +129,8 @@ paths:
       tags:
       - Secrets Manager
       parameters:
-      - description: "ID of the secret to delete. Must match the regex ^[a-zA-Z0-9_\\\
-          .-]+$ and must exist."
+      - description: "ID of the secret to delete. Must match the regex ^[a-zA-Z0-9_.-]+$\
+          \ and must exist."
         required: true
         name: id
         in: path

--- a/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
+++ b/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
@@ -64,7 +64,7 @@ public class SecretsManagerResource {
     /**
      * Regular expression for validating secret IDs.
      */
-    private static final String SECRET_ID_REGEX = "^[a-zA-Z0-9_\\.-]+$";
+    private static final String SECRET_ID_REGEX = "^[a-zA-Z0-9_.-]+$";
 
     private final RealmModel realm;
     private final AdminPermissionEvaluator auth;
@@ -270,13 +270,15 @@ public class SecretsManagerResource {
             return;
         }
 
-        logger.debugv("Evicting secret cache for path {0}", fullPath);
+        String cacheKey = fullPath + ":" + SECRET_FIELD_NAME;
+
+        logger.debugv("Evicting secret cache (key: {0})", cacheKey);
         session.getProvider(InfinispanConnectionProvider.class)
-                .getCache(providerConfig.getCacheName()).remove(fullPath);
+                .getCache(providerConfig.getCacheName()).remove(cacheKey);
     }
 
     private static String createRandomSecretValue() {
-        var random = new SecureRandom();
+        SecureRandom random = new SecureRandom();
         return random.ints(60, 0, SECRET_CHARS.length())
                 .mapToObj(SECRET_CHARS::charAt)
                 .collect(StringBuilder::new, StringBuilder::append, StringBuilder::append)

--- a/src/test/java/io/github/nordix/junit/KeycloakRestClientExtension.java
+++ b/src/test/java/io/github/nordix/junit/KeycloakRestClientExtension.java
@@ -96,7 +96,7 @@ public class KeycloakRestClientExtension extends RestClient implements BeforeEac
         logger.infov("Waiting for Keycloak to be ready (max {0} times)", maxNotReady);
         while (true) {
             try {
-                var resp = this.sendRequest("/realms/master", "GET");
+                HttpResponse<JsonNode> resp = this.sendRequest("/realms/master", "GET");
                 if (isSuccessfulResponse(resp)) {
                     break;
                 }


### PR DESCRIPTION
* Adds tests and documentation for `${vault.my-secret:my-key}` format.
* Fixes bug where wrong Infinispan cache key was used when specifying non-default key with `${vault.my-secret:my-key}` format.
* Adds documentation on secrets manager storage layout.

Closes #32 
Closes #33