### PR TITLE
Delete non-existing secret returns 204

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -171,9 +171,6 @@
           "204" : {
             "description" : "Secret deleted successfully"
           },
-          "404" : {
-            "description" : "Secret not found"
-          },
           "400" : {
             "description" : "Bad request, e.g., invalid ID format"
           },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -140,8 +140,6 @@ paths:
       responses:
         "204":
           description: Secret deleted successfully
-        "404":
-          description: Secret not found
         "400":
           description: "Bad request, e.g., invalid ID format"
         "500":

--- a/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
+++ b/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
@@ -191,7 +191,6 @@ public class SecretsManagerResource {
     @Path("{id}")
     @Operation(summary = "Delete a secret", description = "Deletes a secret by its ID.")
     @APIResponse(responseCode = "204", description = "Secret deleted successfully")
-    @APIResponse(responseCode = "404", description = "Secret not found")
     @APIResponse(responseCode = "400", description = "Bad request, e.g., invalid ID format")
     @APIResponse(responseCode = "500", description = "Internal server error")
     public Response deleteSecret(
@@ -210,12 +209,8 @@ public class SecretsManagerResource {
             evictSecretCache(fullPath);
             return Response.noContent().build();
         } catch (BaoClient.BaoClientException e) {
-            if (e.getStatusCode() == 404) {
-                throw ErrorResponse.error("Secret not found", Response.Status.NOT_FOUND);
-            } else {
-                logger.errorv(e, "Error deleting secret {0} for realm {1}", id, realm.getName());
-                throw ErrorResponse.error("Error deleting secret", Response.Status.INTERNAL_SERVER_ERROR);
-            }
+            logger.errorv(e, "Error deleting secret {0} for realm {1}", id, realm.getName());
+            throw ErrorResponse.error("Error deleting secret", Response.Status.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
@@ -234,6 +234,12 @@ class SecretsManagerIT {
                 .sendRequest(API_PATH + "/" + nonExistentId, "GET");
 
         Assertions.assertEquals(404, getResp.statusCode());
+
+        // Try to delete non-existent secret.
+        // Since DELETE is idempotent, deleting a non-existent secret should still return 204 No Content.
+        HttpResponse<JsonNode> deleteResp = keycloakAdminClient
+                .sendRequest(API_PATH + "/" + nonExistentId, "DELETE");
+        Assertions.assertEquals(204, deleteResp.statusCode());
     }
 
     @Test

--- a/testing/manifests/keycloak.yaml
+++ b/testing/manifests/keycloak.yaml
@@ -70,6 +70,8 @@ spec:
               mkdir -p /opt/keycloak/data/import
               cp /host/testing/configs/keycloak-realms/* /opt/keycloak/data/import/
               cp /host/testing/configs/custom-cache-ispn.xml /opt/keycloak/conf/custom-cache-ispn.xml
+              # For capturing traffic with Wireshark, TLS to OpenBao can be disabled by:
+              # modifying all "nnn--address" parameters from https://openbao:18200 to http://openbao:8200
               /opt/keycloak/bin/kc.sh start \
                 --import-realm \
                 --spi-vault--provider=secrets-provider \


### PR DESCRIPTION
Add new test case and update documentation to clarify that secrets-manager returns successful `204 No Content` even when deleting a non-existent secret, instead of `404 Not Found`.

Since `DELETE` is an idempotent operation, clients should be able to issue the same request multiple times and get the same response. For this reason, OpenBao/Vault also makes no distinction between deleting an existing or non-existent resource, and secrets-manager follows the same behavior.

Note that this change only affects the documentation and test suite. The external behavior has always been `204` and remains unchanged in this PR.