### PR TITLE
Better example of ACL policy for OpenBao

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@ See the [Overview](overview.md) for more information, including the list of Vaul
 
 For detailed API documentation, including request and response schemas, see
 
-- [API documentation](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Nordix/keycloak-secrets-vault-provider/refs/heads/main/docs/openapi.json) (rendering courtesy of petstore.swagger.io).
+- [API documentation](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/Nordix/keycloak-secrets-vault-provider/refs/heads/main/docs/openapi.json) (HTML rendering courtesy of petstore.swagger.io).
 
 ## Access Control and Realm Isolation
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,13 +165,13 @@ To grant these permissions, create the following policies:
 
 ```bash
 bao policy write keycloak/reader - <<EOF
-path "secret/*" {
+path "secret/keycloak/*" {
     capabilities = ["read"]
 }
 EOF
 
 bao policy write keycloak/admin - <<EOF
-path "secret/*" {
+path "secret/keycloak/*" {
     capabilities = ["create", "read", "update", "delete", "list"]
 }
 EOF
@@ -204,7 +204,7 @@ The extensions use the specified role during authentication to obtain a token.
 Enable the KV secrets engine at your desired path:
 
 ```
-bao secrets enable kv --path secret/
+bao secrets enable --path=secret/ kv
 ```
 
 This project currently supports only KV version 1.

--- a/src/test/java/io/github/nordix/junit/Metrics.java
+++ b/src/test/java/io/github/nordix/junit/Metrics.java
@@ -95,13 +95,13 @@ public class Metrics {
     private static BodyHandler<Map<String, String>> prometheusFormatBodyHandler() {
         // Example for Prometheus text format:
         //
-        // # HELP vault_route_list_secretv1_ vault_route_list_secretv1_
-        // # TYPE vault_route_list_secretv1_ summary
-        // vault_route_list_secretv1_{quantile="0.5"} NaN
-        // vault_route_list_secretv1_{quantile="0.9"} NaN
-        // vault_route_list_secretv1_{quantile="0.99"} NaN
-        // vault_route_list_secretv1__sum 0.16811500489711761
-        // vault_route_list_secretv1__count 1
+        // # HELP vault_route_list_secret_ vault_route_list_secret_
+        // # TYPE vault_route_list_secret_ summary
+        // vault_route_list_secret_{quantile="0.5"} NaN
+        // vault_route_list_secret_{quantile="0.9"} NaN
+        // vault_route_list_secret_{quantile="0.99"} NaN
+        // vault_route_list_secret__sum 0.16811500489711761
+        // vault_route_list_secret__count 1
         return respInfo -> BodySubscribers.mapping(
                 BodySubscribers.ofString(StandardCharsets.UTF_8),
                 body -> {

--- a/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
@@ -68,8 +68,8 @@ class SecretsManagerIT {
         Assertions.assertEquals(secretValue, getResp.body().get("secret").asText());
         Assertions.assertEquals(vaultId, getResp.body().get("vault_id").asText());
 
-        metrics.assertCounterIncrementedBy("vault_route_create_secretv1__count", 1);
-        metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_create_secret__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_read_secret__count", 1);
     }
 
     @Test
@@ -106,7 +106,7 @@ class SecretsManagerIT {
         Assertions.assertEquals(60, createResp2.body().get("secret").asText().length());
         Assertions.assertEquals(secretId2, createResp2.body().get("id").asText());
 
-        metrics.assertCounterIncrementedBy("vault_route_create_secretv1__count", 2);
+        metrics.assertCounterIncrementedBy("vault_route_create_secret__count", 2);
     }
 
     @Test
@@ -138,8 +138,8 @@ class SecretsManagerIT {
         Assertions.assertTrue(RestClient.isSuccessfulResponse(getResp), "Failed to read secret: " + getResp.body());
         Assertions.assertEquals(updatedValue, getResp.body().get("secret").asText());
 
-        metrics.assertCounterIncrementedBy("vault_route_create_secretv1__count", 1);
-        metrics.assertCounterIncrementedBy("vault_route_update_secretv1__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_create_secret__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_update_secret__count", 1);
     }
 
     @Test
@@ -166,8 +166,8 @@ class SecretsManagerIT {
         // Verify that the updated value is not the same as the initial value.
         Assertions.assertNotEquals(initialRandomValue, newRandomValue);
 
-        metrics.assertCounterIncrementedBy("vault_route_create_secretv1__count", 1);
-        metrics.assertCounterIncrementedBy("vault_route_update_secretv1__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_create_secret__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_update_secret__count", 1);
     }
 
     @Test
@@ -193,7 +193,7 @@ class SecretsManagerIT {
 
         Assertions.assertEquals(404, getResp.statusCode());
 
-        metrics.assertCounterIncrementedBy("vault_route_delete_secretv1__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_delete_secret__count", 1);
 
     }
 
@@ -222,7 +222,7 @@ class SecretsManagerIT {
         Assertions.assertTrue(ids.contains(secretId1));
         Assertions.assertTrue(ids.contains(secretId2));
 
-        metrics.assertCounterIncrementedBy("vault_route_list_secretv1__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_list_secret__count", 1);
     }
 
     @Test
@@ -308,11 +308,11 @@ class SecretsManagerIT {
             Assertions.assertEquals(403, listResp.statusCode());
 
             // Check that no requests were made to OpenBao.
-            metrics.assertCounterIncrementedBy("vault_route_create_secretv1__count", 0);
-            metrics.assertCounterIncrementedBy("vault_route_update_secretv1__count", 0);
-            metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 0);
-            metrics.assertCounterIncrementedBy("vault_route_list_secretv1__count", 0);
-            metrics.assertCounterIncrementedBy("vault_route_delete_secretv1__count", 0);
+            metrics.assertCounterIncrementedBy("vault_route_create_secret__count", 0);
+            metrics.assertCounterIncrementedBy("vault_route_update_secret__count", 0);
+            metrics.assertCounterIncrementedBy("vault_route_read_secret__count", 0);
+            metrics.assertCounterIncrementedBy("vault_route_list_secret__count", 0);
+            metrics.assertCounterIncrementedBy("vault_route_delete_secret__count", 0);
 
         } finally {
             keycloakAdminClient.deleteRealm("unauthorized");

--- a/src/test/java/io/github/nordix/keycloak/services/vault/SecretsProviderIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/vault/SecretsProviderIT.java
@@ -160,7 +160,7 @@ class SecretsProviderIT {
                 "Expected successful login when valid vault secret reference is used");
 
         // Check that the secret was only fetched once by Keycloak 0 and Keycloak 1 accessed it from the cache.
-        metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 1);
+        metrics.assertCounterIncrementedBy("vault_route_read_secret__count", 1);
     }
 
     @Test
@@ -185,7 +185,7 @@ class SecretsProviderIT {
                 "Expected successful login when updated vault secret reference is used");
 
         // Check that there was two reads from OpenBao: one from Keycloak 0 and one from Keycloak 1 after the update.
-        metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 2);
+        metrics.assertCounterIncrementedBy("vault_route_read_secret__count", 2);
     }
 
     /**
@@ -224,7 +224,7 @@ class SecretsProviderIT {
                 "Expected successful login when valid vault secret reference is used");
 
         // Check that the secret was fetched 2 times (2 cache misses).
-        metrics.assertCounterIncrementedBy("vault_route_read_secretv1__count", 2);
+        metrics.assertCounterIncrementedBy("vault_route_read_secret__count", 2);
     }
 
     AuthenticationResult performBrowserLogin(String username, String password) {

--- a/testing/manifests/keycloak.yaml
+++ b/testing/manifests/keycloak.yaml
@@ -77,14 +77,14 @@ spec:
                 --spi-vault--provider=secrets-provider \
                 --spi-vault--secrets-provider--address=https://openbao:18200 \
                 --spi-vault--secrets-provider--ca-certificate-file=/host/testing/certs/ca.pem \
-                --spi-vault--secrets-provider--kv-mount=secretv1 \
+                --spi-vault--secrets-provider--kv-mount=secret \
                 --spi-vault--secrets-provider--kv-path-prefix="keycloak/%realm%" \
                 --spi-vault--secrets-provider--kv-version=1 \
                 --spi-vault--secrets-provider--role=keycloak-reader \
                 --spi-vault--secrets-provider--cache-name=vaultExtensionSecrets \
                 --spi-admin-realm-restapi-extension--secrets-manager--address=https://openbao:18200 \
                 --spi-admin-realm-restapi-extension--secrets-manager--ca-certificate-file=/host/testing/certs/ca.pem \
-                --spi-admin-realm-restapi-extension--secrets-manager--kv-mount=secretv1 \
+                --spi-admin-realm-restapi-extension--secrets-manager--kv-mount=secret \
                 --spi-admin-realm-restapi-extension--secrets-manager--kv-path-prefix="keycloak/%realm%" \
                 --spi-admin-realm-restapi-extension--secrets-manager--kv-version=1 \
                 --spi-admin-realm-restapi-extension--secrets-manager--role=keycloak-admin \

--- a/testing/manifests/openbao.yaml
+++ b/testing/manifests/openbao.yaml
@@ -157,16 +157,16 @@ data:
     bao write auth/kubernetes/config kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT
 
     # Enable kv1 secrets engine.
-    bao secrets enable --path=secretv1 kv
+    bao secrets enable --path=secret/ kv
 
     # Configure policies.
     bao policy write keycloak/reader - <<EOF
-    path "secretv1/*" {
+    path "secret/keycloak/*" {
       capabilities = ["read"]
     }
     EOF
     bao policy write keycloak/admin - <<EOF
-    path "secretv1/*" {
+    path "secret/keycloak/*" {
       capabilities = ["create", "read", "update", "delete", "list"]
     }
     EOF


### PR DESCRIPTION
* Tighten the ACL policy in the OpenBao configuration example.
* Align the KV secrets engine mount path in the dev environment with the deployment documentation example.