### PR TITLE
Parametrize secret generation and add more docs on random password generation

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -88,17 +88,40 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "description" : "Character classes to use for random secret generation. Ignored if secret data is provided. Specify as comma-separated values: 'lower' (a-z), 'upper' (A-Z), 'digit' (0-9), 'special' (@#%^-_=+.:)",
+          "example" : "lower,upper",
+          "required" : false,
+          "name" : "charset",
+          "in" : "query",
+          "schema" : {
+            "type" : "string",
+            "default" : "lower,upper,digit,special"
+          }
+        }, {
+          "description" : "Number of characters in the generated random secret. Ignored if secret data is provided.",
+          "example" : 32,
+          "required" : false,
+          "name" : "length",
+          "in" : "query",
+          "schema" : {
+            "maximum" : 2048,
+            "minimum" : 1,
+            "format" : "int32",
+            "type" : "integer",
+            "default" : 60
+          }
         } ],
         "requestBody" : {
           "description" : "Optional secret data. If not provided, a random secret will be generated.",
-          "required" : false,
           "content" : {
             "application/json" : {
               "schema" : {
                 "$ref" : "#/components/schemas/SecretRequest"
               }
             }
-          }
+          },
+          "required" : false
         },
         "responses" : {
           "200" : {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -79,14 +79,36 @@ paths:
         in: path
         schema:
           type: string
+      - description: "Character classes to use for random secret generation. Ignored\
+          \ if secret data is provided. Specify as comma-separated values: 'lower'\
+          \ (a-z), 'upper' (A-Z), 'digit' (0-9), 'special' (@#%^-_=+.:)"
+        example: "lower,upper"
+        required: false
+        name: charset
+        in: query
+        schema:
+          type: string
+          default: "lower,upper,digit,special"
+      - description: Number of characters in the generated random secret. Ignored
+          if secret data is provided.
+        example: 32
+        required: false
+        name: length
+        in: query
+        schema:
+          maximum: 2048
+          minimum: 1
+          format: int32
+          type: integer
+          default: 60
       requestBody:
         description: "Optional secret data. If not provided, a random secret will\
           \ be generated."
-        required: false
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/SecretRequest"
+        required: false
       responses:
         "200":
           description: Secret created or updated


### PR DESCRIPTION
The `PUT .../secrets-manager/{id}` endpoint now supports customizing random password generation by specifying the desired length and character classes.

New optional query parameters:

* `length=<integer>` defines the number of characters in the generated password (default value: `60`)
* `charset=<comma-separated list>` specifies which character classes to include; valid values are `lower`, `upper`, `digit`, and `special` (default value: `lower,upper,digit,special`)

Example usage

`PUT .../secrets-manager/my-secret?length=16&charset=lower,upper,digit`

If query parameters are provided with secret data in the request body, the query parameters are ignored.
