### PR TITLE
Added support for keycloak-26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build and test
         run: |
-          ./mvnw clean verify --batch-mode --update-snapshots -DmanageTestEnv=true
+          ./mvnw clean verify --batch-mode --update-snapshots -DmanageTestEnv=true -Pkeycloak-current

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ To build the project without running tests:
 ./mvnw clean package -DskipTests
 ```
 
+This compiles the source code and creates a JAR file in the `target` directory for use in subsequent steps.
+
 ## Local Development Environment
 
 > **Note:** Integration tests require [kind](https://kind.sigs.k8s.io/) and [kubectl](https://kubernetes.io/docs/tasks/tools/) to be installed.
@@ -19,7 +21,7 @@ To avoid repeatedly setting up the environment during development, you can first
 1. Create a Kind cluster
 
     ```bash
-    ./mvnw pre-integration-test -DmanageTestEnv=true
+    ./mvnw pre-integration-test -DmanageTestEnv=true -Dmaven.main.skip -Dmaven.test.skip
     ```
 
     You can then run the tests against the manually created environment without needing to set up the cluster each time.
@@ -30,6 +32,11 @@ To avoid repeatedly setting up the environment during development, you can first
     - Generate certificates for internal communication between Keycloak and OpenBao.
     - Deploy Keycloak with the compiled JAR, configure two realms ("first" and "second") and create a user in the "second" realm for testing identity brokering with IdP secret using Vault SPI.
     - Deploy OpenBao, initialize and unseal, configure KV secrets engine, and create a roles and policies for Keycloak.
+
+    Note: If you make changes to the code, remember to rebuild the project using `./mvnw clean package -DskipTests` and restart Keycloak to pick up the changes by deleting the Keycloak pods `kubectl delete pods -l app=keycloak`.
+
+    Note: `-Dmaven.main.skip` and `-Dmaven.test.skip` are used to skip building the main and test code during this setup phase.
+    If you want to also build the code then add the Keycloak version profile you are working on, e.g. `./mvnw pre-integration-test -Pkeycloak-current -DmanageTestEnv=true`.
 
 2. Run tests
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,10 +17,31 @@ To deploy the Vault SPI Secrets Provider and Secrets Manager REST API extension,
 
    This will produce a JAR file in the `target/` directory.
 
+   ⚠️ See the section [Keycloak Version Compatibility Profiles](#keycloak-version-compatibility-profiles) below.
+
 2. Copy the JAR to Keycloak
 
    Copy the compiled JAR file to the `providers/` directory of your Keycloak installation.
    For example, if using the official [Keycloak container image](https://www.keycloak.org/server/containers), the extension should be placed in the `/opt/keycloak/providers/` directory.
+
+## Keycloak Version Compatibility Profiles
+
+This project supports multiple Keycloak versions using Maven profiles.
+Select the profile that matches your target Keycloak version when building.
+
+| Profile ID         | Keycloak Version  | Source Directory     | Activation                |
+|--------------------|-------------------|----------------------|---------------------------|
+| keycloak-current   | Latest            | `src/compat/current` | Active by default         |
+| keycloak-26.2      | 26.2.x            | `src/compat/26.2`    | `-Pkeycloak-26.2`         |
+
+By default, the project builds against Keycloak 26.3.x and newer by using `keycloak-current` profile.
+The default profile is kept up to date with new Keycloak releases using Dependabot and automated tests in GitHub Actions.
+
+To build for Keycloak 26.2.x, run:
+
+```bash
+./mvnw clean package -Dmaven.test.skip -Pkeycloak-26.2
+```
 
 ## Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <version.maven.jacoco.plugin>0.8.13</version.maven.jacoco.plugin>
     <version.maven.shade.plugin>3.5.1</version.maven.shade.plugin>
     <version.maven.exec.plugin>3.6.2</version.maven.exec.plugin>
+    <version.maven.build.helper.plugin>3.6.1</version.maven.build.helper.plugin>
     <version.selenium>4.38.0</version.selenium>
     <version.certy>0.4.1</version.certy>
   </properties>
@@ -276,8 +277,82 @@
 
   </build>
 
-  <!-- Integration test: manage test environment when given -DmanageTestEnv=true -->
   <profiles>
+
+    <!-- Conditional compilation for compatibility with different Keycloak versions -->
+
+    <!-- Default profile: keycloak-current will compile against the latest Keycloak version.
+         This profile compiles the code against the latest Keycloak APIs.
+         Version is being updated by github dependabot automatically.
+         See src/compat/current/java for the code.
+    -->
+    <profile>
+      <id>keycloak-current</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>${version.maven.build.helper.plugin}</version>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/compat/current/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Keycloak 26.2.x profile.
+         This profile compiles the code against Keycloak 26.2.x APIs.
+         See src/compat/26.2/java for the code.
+         To use this profile, run
+           ./mvnw clean package -Pkeycloak-26.2
+    -->
+    <profile>
+      <id>keycloak-26.2</id>
+      <properties>
+        <version.keycloak>26.2.4</version.keycloak>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>${version.maven.build.helper.plugin}</version>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/compat/26.2/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+
+
+    <!-- Integration test: manage test environment when given -DmanageTestEnv=true -->
     <profile>
       <id>manage-test-environment</id>
       <activation>

--- a/src/compat/26.2/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerProviderCompat.java
+++ b/src/compat/26.2/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerProviderCompat.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2025 OpenInfra Foundation Europe and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.nordix.keycloak.services.secretsmanager;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.ext.AdminRealmResourceProvider;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+
+import io.github.nordix.keycloak.common.ProviderConfig;
+
+public class SecretsManagerProviderCompat implements AdminRealmResourceProvider {
+
+    private static Logger logger = Logger.getLogger(SecretsManagerProviderCompat.class);
+    private final ProviderConfig providerConfig;
+
+    public SecretsManagerProviderCompat(ProviderConfig providerConfig) {
+        logger.debugf("Creating SecretManagerProvider instance");
+        this.providerConfig = providerConfig;
+    }
+
+    @Override
+    public void close() {
+        // Intentionally left empty.
+    }
+
+    @Override
+    public Object getResource(KeycloakSession session, RealmModel realm, AdminPermissionEvaluator auth,
+            AdminEventBuilder adminEvent) {
+        logger.debugv("Creating SecretManagerProvider for session: {0}, realm: {1}", session, realm.getName());
+        return new SecretsManagerResourceCompat(session, realm, auth, adminEvent, providerConfig);
+    }
+}

--- a/src/compat/26.2/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResourceCompat.java
+++ b/src/compat/26.2/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResourceCompat.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2025 OpenInfra Foundation Europe and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.nordix.keycloak.services.secretsmanager;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+
+import io.github.nordix.keycloak.common.ProviderConfig;
+
+public class SecretsManagerResourceCompat extends SecretsManagerResource {
+
+    private final AdminPermissionEvaluator auth;
+
+    public SecretsManagerResourceCompat(KeycloakSession session,
+            RealmModel realm,
+            AdminPermissionEvaluator auth,
+            AdminEventBuilder adminEvent,
+            ProviderConfig providerConfig) {
+        super(session, realm, adminEvent, providerConfig);
+        this.auth = auth;
+    }
+
+    protected void authorizeRequest() {
+        // Check manage-realm permission, throws if unauthorized.
+        auth.realm().requireManageRealm();
+    }
+}

--- a/src/compat/current/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerProviderCompat.java
+++ b/src/compat/current/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerProviderCompat.java
@@ -18,12 +18,12 @@ import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 
 import io.github.nordix.keycloak.common.ProviderConfig;
 
-public class SecretsManagerProvider implements AdminRealmResourceProvider {
+public class SecretsManagerProviderCompat implements AdminRealmResourceProvider {
 
-    private static Logger logger = Logger.getLogger(SecretsManagerProvider.class);
+    private static Logger logger = Logger.getLogger(SecretsManagerProviderCompat.class);
     private final ProviderConfig providerConfig;
 
-    public SecretsManagerProvider(ProviderConfig providerConfig) {
+    public SecretsManagerProviderCompat(ProviderConfig providerConfig) {
         logger.debugf("Creating SecretManagerProvider instance");
         this.providerConfig = providerConfig;
     }
@@ -37,6 +37,6 @@ public class SecretsManagerProvider implements AdminRealmResourceProvider {
     public Object getResource(KeycloakSession session, RealmModel realm, AdminPermissionEvaluator auth,
             AdminEventBuilder adminEvent) {
         logger.debugv("Creating SecretManagerProvider for session: {0}, realm: {1}", session, realm.getName());
-        return new SecretsManagerResource(session, realm, auth, adminEvent, providerConfig);
+        return new SecretsManagerResourceCompat(session, realm, auth, adminEvent, providerConfig);
     }
 }

--- a/src/compat/current/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResourceCompat.java
+++ b/src/compat/current/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResourceCompat.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2025 OpenInfra Foundation Europe and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.github.nordix.keycloak.services.secretsmanager;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+
+import io.github.nordix.keycloak.common.ProviderConfig;
+
+public class SecretsManagerResourceCompat extends SecretsManagerResource {
+
+    private final AdminPermissionEvaluator auth;
+
+    public SecretsManagerResourceCompat(KeycloakSession session,
+            RealmModel realm,
+            AdminPermissionEvaluator auth,
+            AdminEventBuilder adminEvent,
+            ProviderConfig providerConfig) {
+        super(session, realm, adminEvent, providerConfig);
+        this.auth = auth;
+    }
+
+    protected void authorizeRequest() {
+        // Check manage-realm permission, throws if unauthorized.
+        auth.realm().requireManageRealm();
+    }
+}

--- a/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerProviderFactory.java
+++ b/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerProviderFactory.java
@@ -35,7 +35,7 @@ public class SecretsManagerProviderFactory implements AdminRealmResourceProvider
     @Override
     public AdminRealmResourceProvider create(KeycloakSession session) {
         logger.debug("Creating SecretManagerProvider");
-        return new SecretsManagerProvider(config);
+        return new SecretsManagerProviderCompat(config);
     }
 
     @Override


### PR DESCRIPTION
Added support for optional build profiles for

* `keycloak-current` which compiles with Keycloak 26.3 and later.
* `keycloak-26.2` which compiles with Keycloak 26.2 and earlier.