### PR TITLE
feat: make Vault client timeouts configurable

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,6 +86,10 @@ The provider works with both OpenBao and HashiCorp Vault, since both implement t
 | `--spi-vault--secrets-provider--ca-certificate-file`  | Path to CA certificate file for HTTPS connections. Optional.              | N/A                                                   |
 | `--spi-vault--secrets-provider--role`                 | Role to use for authentication.                                           | N/A                                                   |
 | `--spi-vault--secrets-provider--cache-name`           | Name of the Infinispan cache to use for storing secrets.                  | Caching is disabled                                   |
+| `--spi-vault--secrets-provider--connect-timeout-seconds`  | Timeout (seconds) for establishing the connection to the server.      | `3`                                                   |
+| `--spi-vault--secrets-provider--request-timeout-seconds`  | Timeout (seconds) for a single request to the server.                 | `10`                                                  |
+| `--spi-vault--secrets-provider--retry-max`            | Maximum number of retries on connection-phase failures (connection refused / connect timeout). `0` disables retry. Only connection-phase failures are retried; failures after the connection is established are never retried. | `0` |
+| `--spi-vault--secrets-provider--retry-backoff-seconds` | Base backoff (seconds) between retries, scaled per attempt (backoff × attempt). Applies only when `retry-max` > 0. | `2` |
 
 <sup>1</sup> Only `kubernetes` is supported.
 
@@ -114,6 +118,10 @@ This separate configuration is necessary because the Vault Secrets Provider and 
 | `--spi-admin-realm-restapi-extension--secrets-manager--ca-certificate-file`  | Path to CA certificate file for HTTPS connections. Optional.                                      | N/A                                                   |
 | `--spi-admin-realm-restapi-extension--secrets-manager--role`                 | Role to use for authentication.                                                                   | N/A                                                   |
 | `--spi-admin-realm-restapi-extension--secrets-manager--cache-name`           | Name of the Infinispan cache to use for storing secrets.                                          | Caching is disabled                                   |
+| `--spi-admin-realm-restapi-extension--secrets-manager--connect-timeout-seconds`  | Timeout (seconds) for establishing the connection to the server.                              | `3`                                                   |
+| `--spi-admin-realm-restapi-extension--secrets-manager--request-timeout-seconds`  | Timeout (seconds) for a single request to the server.                                         | `10`                                                  |
+| `--spi-admin-realm-restapi-extension--secrets-manager--retry-max`            | Maximum number of retries on connection-phase failures (connection refused / connect timeout). `0` disables retry. Only connection-phase failures are retried; failures after the connection is established are never retried. | `0` |
+| `--spi-admin-realm-restapi-extension--secrets-manager--retry-backoff-seconds` | Base backoff (seconds) between retries, scaled per attempt (backoff × attempt). Applies only when `retry-max` > 0. | `2` |
 
 <sup>1</sup> Only `kubernetes` is supported.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,8 +88,6 @@ The provider works with both OpenBao and HashiCorp Vault, since both implement t
 | `--spi-vault--secrets-provider--cache-name`           | Name of the Infinispan cache to use for storing secrets.                  | Caching is disabled                                   |
 | `--spi-vault--secrets-provider--connect-timeout-seconds`  | Timeout (seconds) for establishing the connection to the server.      | `3`                                                   |
 | `--spi-vault--secrets-provider--request-timeout-seconds`  | Timeout (seconds) for a single request to the server.                 | `10`                                                  |
-| `--spi-vault--secrets-provider--retry-max`            | Maximum number of retries on connection-phase failures (connection refused / connect timeout). `0` disables retry. Only connection-phase failures are retried; failures after the connection is established are never retried. | `0` |
-| `--spi-vault--secrets-provider--retry-backoff-seconds` | Base backoff (seconds) between retries, scaled per attempt (backoff × attempt). Applies only when `retry-max` > 0. | `2` |
 
 <sup>1</sup> Only `kubernetes` is supported.
 
@@ -120,8 +118,6 @@ This separate configuration is necessary because the Vault Secrets Provider and 
 | `--spi-admin-realm-restapi-extension--secrets-manager--cache-name`           | Name of the Infinispan cache to use for storing secrets.                                          | Caching is disabled                                   |
 | `--spi-admin-realm-restapi-extension--secrets-manager--connect-timeout-seconds`  | Timeout (seconds) for establishing the connection to the server.                              | `3`                                                   |
 | `--spi-admin-realm-restapi-extension--secrets-manager--request-timeout-seconds`  | Timeout (seconds) for a single request to the server.                                         | `10`                                                  |
-| `--spi-admin-realm-restapi-extension--secrets-manager--retry-max`            | Maximum number of retries on connection-phase failures (connection refused / connect timeout). `0` disables retry. Only connection-phase failures are retried; failures after the connection is established are never retried. | `0` |
-| `--spi-admin-realm-restapi-extension--secrets-manager--retry-backoff-seconds` | Base backoff (seconds) between retries, scaled per attempt (backoff × attempt). Applies only when `retry-max` > 0. | `2` |
 
 <sup>1</sup> Only `kubernetes` is supported.
 

--- a/src/main/java/io/github/nordix/baoclient/BaoClient.java
+++ b/src/main/java/io/github/nordix/baoclient/BaoClient.java
@@ -68,18 +68,6 @@ public class BaoClient {
     }
 
     /**
-     * Configures bounded retry with backoff for transient connection failures.
-     *
-     * @param maxRetries   maximum number of retries after the first attempt.
-     * @param retryBackoff base backoff between retries (scaled per attempt).
-     * @return This BaoClient instance for method chaining.
-     */
-    public BaoClient withRetry(int maxRetries, java.time.Duration retryBackoff) {
-        httpClient.withRetry(maxRetries, retryBackoff);
-        return this;
-    }
-
-    /**
      * Sets the authentication token to be used by the HTTP client.
      *
      * @param token The authentication token.

--- a/src/main/java/io/github/nordix/baoclient/BaoClient.java
+++ b/src/main/java/io/github/nordix/baoclient/BaoClient.java
@@ -46,6 +46,40 @@ public class BaoClient {
     }
 
     /**
+     * Sets the connection (connect) timeout used by the underlying HTTP client.
+     *
+     * @param connectTimeout the connect timeout.
+     * @return This BaoClient instance for method chaining.
+     */
+    public BaoClient withConnectTimeout(java.time.Duration connectTimeout) {
+        httpClient.withConnectTimeout(connectTimeout);
+        return this;
+    }
+
+    /**
+     * Sets the per-request timeout used by the underlying HTTP client.
+     *
+     * @param requestTimeout the request timeout.
+     * @return This BaoClient instance for method chaining.
+     */
+    public BaoClient withRequestTimeout(java.time.Duration requestTimeout) {
+        httpClient.withRequestTimeout(requestTimeout);
+        return this;
+    }
+
+    /**
+     * Configures bounded retry with backoff for transient connection failures.
+     *
+     * @param maxRetries   maximum number of retries after the first attempt.
+     * @param retryBackoff base backoff between retries (scaled per attempt).
+     * @return This BaoClient instance for method chaining.
+     */
+    public BaoClient withRetry(int maxRetries, java.time.Duration retryBackoff) {
+        httpClient.withRetry(maxRetries, retryBackoff);
+        return this;
+    }
+
+    /**
      * Sets the authentication token to be used by the HTTP client.
      *
      * @param token The authentication token.

--- a/src/main/java/io/github/nordix/baoclient/RestClient.java
+++ b/src/main/java/io/github/nordix/baoclient/RestClient.java
@@ -9,9 +9,11 @@
 package io.github.nordix.baoclient;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Builder;
+import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
@@ -39,13 +41,29 @@ public class RestClient {
     private static Logger logger = Logger.getLogger(RestClient.class);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final Duration CONNECTION_TIMEOUT = Duration.ofSeconds(3);
-    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    // Default connection settings. The connect (3s) and request (10s) timeouts are
+    // fast-fail defaults matching the previous hard-coded behaviour; on their own they do
+    // not ride out a transient backend outage. Resilience against a transient connection
+    // failure (for example while the backend is briefly unavailable during a restart or
+    // failover) is provided by the optional retry, which is OFF by default (maxRetries = 0)
+    // so the client's behaviour is unchanged unless the caller opts in via withRetry(...).
+    // All values can be overridden per-instance via the with* setters below.
+    private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final int DEFAULT_MAX_RETRIES = 0;
+    private static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofSeconds(2);
+
     private static final String CONTENT_TYPE_JSON = "application/json";
 
     private final URI baseUrl;
     private String caCertificateFile;
     private Map<String, String> headers = new java.util.HashMap<>();
+
+    private Duration connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+    private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+    private int maxRetries = DEFAULT_MAX_RETRIES;
+    private Duration retryBackoff = DEFAULT_RETRY_BACKOFF;
 
     public RestClient(URI baseUrl) {
         this.baseUrl = baseUrl;
@@ -57,7 +75,7 @@ public class RestClient {
 
         HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(baseUrl.resolve(endpoint))
-                .timeout(REQUEST_TIMEOUT)
+                .timeout(requestTimeout)
                 .header("Content-Type", CONTENT_TYPE_JSON);
 
         headers.forEach(requestBuilder::header);
@@ -75,15 +93,61 @@ public class RestClient {
         HttpRequest request = requestBuilder.build();
         logger.debugv("Sending {0} request to {1}", method, request.uri());
 
+        // Build the client once and reuse it across retry attempts.
+        HttpClient client = getHttpClient();
+
+        int attempt = 0;
+        while (true) {
+            try {
+                return client.send(request, jsonBodyHandler());
+            } catch (HttpConnectTimeoutException | ConnectException e) {
+                // Connection-phase failures are caught separately from all other
+                // IOExceptions on purpose, to draw a clear safety boundary for retries:
+                //
+                //  * A failure to establish the connection (connection refused or connect
+                //    timeout) guarantees the request never reached the server. Re-sending
+                //    it therefore cannot cause duplicate side effects, so it is safe to
+                //    retry regardless of HTTP method - including non-idempotent writes.
+                //
+                //  * Any failure AFTER the connection is established (request timeout,
+                //    other IOException, or an error status code) may mean the server
+                //    already received and partially processed the request. Retrying those
+                //    could double-apply a write, so they are intentionally NOT retried
+                //    here and fall through to the generic handler below.
+                //
+                // This connection-phase failure is the mode seen when the backend is
+                // briefly unavailable, e.g. during a restart or failover. Retry is opt-in
+                // (maxRetries defaults to 0); when it is disabled this block simply rethrows
+                // on the first failure, preserving the original fail-fast behaviour.
+                if (attempt >= maxRetries) {
+                    throw new RestClientException(String.format(
+                            "Failed to send %s to %s after %d attempt(s): %s",
+                            request.method(), request.uri(), attempt + 1,
+                            e.getCause() != null ? e.getCause() : e), e);
+                }
+                attempt++;
+                long backoffMs = retryBackoff.toMillis() * attempt;
+                logger.warnv(
+                        "Connection to {0} failed (attempt {1}/{2}): {3}. Retrying in {4} ms.",
+                        request.uri(), attempt, maxRetries, e.toString(), backoffMs);
+                sleepBeforeRetry(backoffMs, request.uri().toString());
+            } catch (IOException e) {
+                throw new RestClientException(String.format("Failed to send %s to %s: %s",
+                        request.method(), request.uri(), e.getCause() != null ? e.getCause() : e), e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RestClientException(String.format("Request to %s was interrupted: %s",
+                        request.uri(), e.getMessage()), e);
+            }
+        }
+    }
+
+    private void sleepBeforeRetry(long backoffMs, String uri) {
         try {
-            return getHttpClient().send(request, jsonBodyHandler());
-        } catch (IOException e) {
-            throw new RestClientException(String.format("Failed to send %s to %s: %s",
-                    request.method(), request.uri(), e.getCause() != null ? e.getCause() : e), e);
-        } catch (InterruptedException e) {
+            Thread.sleep(backoffMs);
+        } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
-            throw new RestClientException(String.format("Request to %s was interrupted: %s",
-                    request.uri(), e.getMessage()), e);
+            throw new RestClientException("Retry backoff for " + uri + " was interrupted", ie);
         }
     }
 
@@ -127,6 +191,28 @@ public class RestClient {
         return this;
     }
 
+    public RestClient withConnectTimeout(Duration connectionTimeout) {
+        Objects.requireNonNull(connectionTimeout, "Connection timeout must not be null");
+        this.connectionTimeout = connectionTimeout;
+        return this;
+    }
+
+    public RestClient withRequestTimeout(Duration requestTimeout) {
+        Objects.requireNonNull(requestTimeout, "Request timeout must not be null");
+        this.requestTimeout = requestTimeout;
+        return this;
+    }
+
+    public RestClient withRetry(int maxRetries, Duration retryBackoff) {
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("maxRetries must not be negative");
+        }
+        Objects.requireNonNull(retryBackoff, "Retry backoff must not be null");
+        this.maxRetries = maxRetries;
+        this.retryBackoff = retryBackoff;
+        return this;
+    }
+
     public RestClient withCaCertificateFile(String caCertificateFile) {
         Objects.requireNonNull(caCertificateFile, "CA certificate file must not be null");
         if (!Files.exists(Paths.get(caCertificateFile))) {
@@ -151,7 +237,7 @@ public class RestClient {
     private HttpClient getHttpClient() {
         Builder clientBuilder = HttpClient.newBuilder();
 
-        clientBuilder.connectTimeout(CONNECTION_TIMEOUT);
+        clientBuilder.connectTimeout(connectionTimeout);
         clientBuilder.followRedirects(HttpClient.Redirect.NORMAL);
 
         if (caCertificateFile != null) {

--- a/src/main/java/io/github/nordix/baoclient/RestClient.java
+++ b/src/main/java/io/github/nordix/baoclient/RestClient.java
@@ -9,11 +9,9 @@
 package io.github.nordix.baoclient;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Builder;
-import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
@@ -41,18 +39,8 @@ public class RestClient {
     private static Logger logger = Logger.getLogger(RestClient.class);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    // Default connection settings. The connect (3s) and request (10s) timeouts are
-    // fast-fail defaults matching the previous hard-coded behaviour; on their own they do
-    // not ride out a transient backend outage. Resilience against a transient connection
-    // failure (for example while the backend is briefly unavailable during a restart or
-    // failover) is provided by the optional retry, which is OFF by default (maxRetries = 0)
-    // so the client's behaviour is unchanged unless the caller opts in via withRetry(...).
-    // All values can be overridden per-instance via the with* setters below.
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(3);
     private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(10);
-    private static final int DEFAULT_MAX_RETRIES = 0;
-    private static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofSeconds(2);
 
     private static final String CONTENT_TYPE_JSON = "application/json";
 
@@ -62,8 +50,6 @@ public class RestClient {
 
     private Duration connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
     private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
-    private int maxRetries = DEFAULT_MAX_RETRIES;
-    private Duration retryBackoff = DEFAULT_RETRY_BACKOFF;
 
     public RestClient(URI baseUrl) {
         this.baseUrl = baseUrl;
@@ -93,61 +79,15 @@ public class RestClient {
         HttpRequest request = requestBuilder.build();
         logger.debugv("Sending {0} request to {1}", method, request.uri());
 
-        // Build the client once and reuse it across retry attempts.
-        HttpClient client = getHttpClient();
-
-        int attempt = 0;
-        while (true) {
-            try {
-                return client.send(request, jsonBodyHandler());
-            } catch (HttpConnectTimeoutException | ConnectException e) {
-                // Connection-phase failures are caught separately from all other
-                // IOExceptions on purpose, to draw a clear safety boundary for retries:
-                //
-                //  * A failure to establish the connection (connection refused or connect
-                //    timeout) guarantees the request never reached the server. Re-sending
-                //    it therefore cannot cause duplicate side effects, so it is safe to
-                //    retry regardless of HTTP method - including non-idempotent writes.
-                //
-                //  * Any failure AFTER the connection is established (request timeout,
-                //    other IOException, or an error status code) may mean the server
-                //    already received and partially processed the request. Retrying those
-                //    could double-apply a write, so they are intentionally NOT retried
-                //    here and fall through to the generic handler below.
-                //
-                // This connection-phase failure is the mode seen when the backend is
-                // briefly unavailable, e.g. during a restart or failover. Retry is opt-in
-                // (maxRetries defaults to 0); when it is disabled this block simply rethrows
-                // on the first failure, preserving the original fail-fast behaviour.
-                if (attempt >= maxRetries) {
-                    throw new RestClientException(String.format(
-                            "Failed to send %s to %s after %d attempt(s): %s",
-                            request.method(), request.uri(), attempt + 1,
-                            e.getCause() != null ? e.getCause() : e), e);
-                }
-                attempt++;
-                long backoffMs = retryBackoff.toMillis() * attempt;
-                logger.warnv(
-                        "Connection to {0} failed (attempt {1}/{2}): {3}. Retrying in {4} ms.",
-                        request.uri(), attempt, maxRetries, e.toString(), backoffMs);
-                sleepBeforeRetry(backoffMs, request.uri().toString());
-            } catch (IOException e) {
-                throw new RestClientException(String.format("Failed to send %s to %s: %s",
-                        request.method(), request.uri(), e.getCause() != null ? e.getCause() : e), e);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RestClientException(String.format("Request to %s was interrupted: %s",
-                        request.uri(), e.getMessage()), e);
-            }
-        }
-    }
-
-    private void sleepBeforeRetry(long backoffMs, String uri) {
         try {
-            Thread.sleep(backoffMs);
-        } catch (InterruptedException ie) {
+            return getHttpClient().send(request, jsonBodyHandler());
+        } catch (IOException e) {
+            throw new RestClientException(String.format("Failed to send %s to %s: %s",
+                    request.method(), request.uri(), e.getCause() != null ? e.getCause() : e), e);
+        } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new RestClientException("Retry backoff for " + uri + " was interrupted", ie);
+            throw new RestClientException(String.format("Request to %s was interrupted: %s",
+                    request.uri(), e.getMessage()), e);
         }
     }
 
@@ -200,16 +140,6 @@ public class RestClient {
     public RestClient withRequestTimeout(Duration requestTimeout) {
         Objects.requireNonNull(requestTimeout, "Request timeout must not be null");
         this.requestTimeout = requestTimeout;
-        return this;
-    }
-
-    public RestClient withRetry(int maxRetries, Duration retryBackoff) {
-        if (maxRetries < 0) {
-            throw new IllegalArgumentException("maxRetries must not be negative");
-        }
-        Objects.requireNonNull(retryBackoff, "Retry backoff must not be null");
-        this.maxRetries = maxRetries;
-        this.retryBackoff = retryBackoff;
         return this;
     }
 

--- a/src/main/java/io/github/nordix/keycloak/common/ProviderConfig.java
+++ b/src/main/java/io/github/nordix/keycloak/common/ProviderConfig.java
@@ -30,8 +30,6 @@ public class ProviderConfig {
     private String cacheName;
     private int connectTimeoutSeconds;
     private int requestTimeoutSeconds;
-    private int retryMax;
-    private int retryBackoffSeconds;
 
     public ProviderConfig(Scope configScope, String cmdLineOptionPrefix) {
         this.authMethod = configScope.get("auth-method", "kubernetes");
@@ -44,17 +42,8 @@ public class ProviderConfig {
         this.caCertificateFile = configScope.get("ca-certificate-file");
         this.role = configScope.get("role", "");
         this.cacheName = configScope.get("cache-name");
-        // Connection settings for the backend (OpenBao/Vault). connect-timeout-seconds (3)
-        // and request-timeout-seconds (10) are fast-fail defaults matching the previous
-        // hard-coded values. Retry is opt-in and OFF by default: retry-max defaults to 0
-        // (disabled), so behaviour is unchanged unless the caller sets retry-max > 0 to ride
-        // out a transient connection failure (for example while the backend is briefly
-        // unavailable during a restart or failover). retry-backoff-seconds only applies
-        // when retry-max > 0.
         this.connectTimeoutSeconds = Integer.parseInt(configScope.get("connect-timeout-seconds", "3"));
         this.requestTimeoutSeconds = Integer.parseInt(configScope.get("request-timeout-seconds", "10"));
-        this.retryMax = Integer.parseInt(configScope.get("retry-max", "0"));
-        this.retryBackoffSeconds = Integer.parseInt(configScope.get("retry-backoff-seconds", "2"));
 
         if (address == null) {
             logger.error(cmdLineOptionPrefix + "address + must be provided");
@@ -136,14 +125,6 @@ public class ProviderConfig {
 
     public int getRequestTimeoutSeconds() {
         return requestTimeoutSeconds;
-    }
-
-    public int getRetryMax() {
-        return retryMax;
-    }
-
-    public int getRetryBackoffSeconds() {
-        return retryBackoffSeconds;
     }
 
     @Override

--- a/src/main/java/io/github/nordix/keycloak/common/ProviderConfig.java
+++ b/src/main/java/io/github/nordix/keycloak/common/ProviderConfig.java
@@ -28,6 +28,10 @@ public class ProviderConfig {
     private String caCertificateFile;
     private String role;
     private String cacheName;
+    private int connectTimeoutSeconds;
+    private int requestTimeoutSeconds;
+    private int retryMax;
+    private int retryBackoffSeconds;
 
     public ProviderConfig(Scope configScope, String cmdLineOptionPrefix) {
         this.authMethod = configScope.get("auth-method", "kubernetes");
@@ -40,6 +44,17 @@ public class ProviderConfig {
         this.caCertificateFile = configScope.get("ca-certificate-file");
         this.role = configScope.get("role", "");
         this.cacheName = configScope.get("cache-name");
+        // Connection settings for the backend (OpenBao/Vault). connect-timeout-seconds (3)
+        // and request-timeout-seconds (10) are fast-fail defaults matching the previous
+        // hard-coded values. Retry is opt-in and OFF by default: retry-max defaults to 0
+        // (disabled), so behaviour is unchanged unless the caller sets retry-max > 0 to ride
+        // out a transient connection failure (for example while the backend is briefly
+        // unavailable during a restart or failover). retry-backoff-seconds only applies
+        // when retry-max > 0.
+        this.connectTimeoutSeconds = Integer.parseInt(configScope.get("connect-timeout-seconds", "3"));
+        this.requestTimeoutSeconds = Integer.parseInt(configScope.get("request-timeout-seconds", "10"));
+        this.retryMax = Integer.parseInt(configScope.get("retry-max", "0"));
+        this.retryBackoffSeconds = Integer.parseInt(configScope.get("retry-backoff-seconds", "2"));
 
         if (address == null) {
             logger.error(cmdLineOptionPrefix + "address + must be provided");
@@ -113,6 +128,22 @@ public class ProviderConfig {
 
     public String getCacheName() {
         return cacheName;
+    }
+
+    public int getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public int getRequestTimeoutSeconds() {
+        return requestTimeoutSeconds;
+    }
+
+    public int getRetryMax() {
+        return retryMax;
+    }
+
+    public int getRetryBackoffSeconds() {
+        return retryBackoffSeconds;
     }
 
     @Override

--- a/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
+++ b/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
@@ -249,7 +249,11 @@ abstract public class SecretsManagerResource {
      * Login to OpenBao/HashiCorp Vault.
      */
     private void initializeBaoClient() {
-        this.baoClient = new BaoClient(providerConfig.getAddress());
+        this.baoClient = new BaoClient(providerConfig.getAddress())
+                .withConnectTimeout(java.time.Duration.ofSeconds(providerConfig.getConnectTimeoutSeconds()))
+                .withRequestTimeout(java.time.Duration.ofSeconds(providerConfig.getRequestTimeoutSeconds()))
+                .withRetry(providerConfig.getRetryMax(),
+                        java.time.Duration.ofSeconds(providerConfig.getRetryBackoffSeconds()));
         if (providerConfig.getCaCertificateFile() != null && !providerConfig.getCaCertificateFile().isEmpty()) {
             this.baoClient.withCaCertificateFile(providerConfig.getCaCertificateFile());
         }

--- a/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
+++ b/src/main/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerResource.java
@@ -251,9 +251,7 @@ abstract public class SecretsManagerResource {
     private void initializeBaoClient() {
         this.baoClient = new BaoClient(providerConfig.getAddress())
                 .withConnectTimeout(java.time.Duration.ofSeconds(providerConfig.getConnectTimeoutSeconds()))
-                .withRequestTimeout(java.time.Duration.ofSeconds(providerConfig.getRequestTimeoutSeconds()))
-                .withRetry(providerConfig.getRetryMax(),
-                        java.time.Duration.ofSeconds(providerConfig.getRetryBackoffSeconds()));
+                .withRequestTimeout(java.time.Duration.ofSeconds(providerConfig.getRequestTimeoutSeconds()));
         if (providerConfig.getCaCertificateFile() != null && !providerConfig.getCaCertificateFile().isEmpty()) {
             this.baoClient.withCaCertificateFile(providerConfig.getCaCertificateFile());
         }

--- a/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProvider.java
+++ b/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProvider.java
@@ -160,7 +160,10 @@ public class SecretsProvider implements VaultProvider {
     }
 
     private String fetchSecretFromServer(String fullPath, String fieldName) {
-        BaoClient client = new BaoClient(config.getAddress());
+        BaoClient client = new BaoClient(config.getAddress())
+                .withConnectTimeout(java.time.Duration.ofSeconds(config.getConnectTimeoutSeconds()))
+                .withRequestTimeout(java.time.Duration.ofSeconds(config.getRequestTimeoutSeconds()))
+                .withRetry(config.getRetryMax(), java.time.Duration.ofSeconds(config.getRetryBackoffSeconds()));
 
         if (config.getCaCertificateFile() != null) {
             client.withCaCertificateFile(config.getCaCertificateFile());

--- a/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProvider.java
+++ b/src/main/java/io/github/nordix/keycloak/services/vault/SecretsProvider.java
@@ -162,8 +162,7 @@ public class SecretsProvider implements VaultProvider {
     private String fetchSecretFromServer(String fullPath, String fieldName) {
         BaoClient client = new BaoClient(config.getAddress())
                 .withConnectTimeout(java.time.Duration.ofSeconds(config.getConnectTimeoutSeconds()))
-                .withRequestTimeout(java.time.Duration.ofSeconds(config.getRequestTimeoutSeconds()))
-                .withRetry(config.getRetryMax(), java.time.Duration.ofSeconds(config.getRetryBackoffSeconds()));
+                .withRequestTimeout(java.time.Duration.ofSeconds(config.getRequestTimeoutSeconds()));
 
         if (config.getCaCertificateFile() != null) {
             client.withCaCertificateFile(config.getCaCertificateFile());

--- a/src/test/java/io/github/nordix/baoclient/BaoClientTest.java
+++ b/src/test/java/io/github/nordix/baoclient/BaoClientTest.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,14 +29,19 @@ class BaoClientTest {
     @TempDir
     Path tempDir;
 
-    /**
-     * Test connection refused.
-     * Uses a free port that is not listening, causing ConnectException.
-     */
-    @Test
-    void testConnectionRefused() throws Exception {
+    private Path writeTokenFile() throws IOException {
         Path tokenFile = tempDir.resolve("token");
         Files.writeString(tokenFile, "dummy-jwt-token");
+        return tokenFile;
+    }
+
+    /**
+     * Connection refused with retry disabled: the request is attempted exactly once
+     * (ConnectException) and fails fast.
+     */
+    @Test
+    void testConnectionRefusedNoRetry() throws Exception {
+        Path tokenFile = writeTokenFile();
 
         // Find a free port, then close it so nothing is listening on it.
         int port;
@@ -43,6 +49,35 @@ class BaoClientTest {
             port = s.getLocalPort();
         }
 
+        BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port))
+                .withRetry(0, Duration.ZERO);
+
+        long start = System.currentTimeMillis();
+        RestClientException ex = Assertions.assertThrows(
+                RestClientException.class,
+                () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
+        long elapsed = System.currentTimeMillis() - start;
+
+        Assertions.assertTrue(ex.getMessage().contains("after 1 attempt(s)"), ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("java.net.ConnectException"), ex.getMessage());
+        Assertions.assertTrue(elapsed < 1000, "Expected connection refused immediately but took " + elapsed + "ms");
+    }
+
+    /**
+     * Retry is opt-in: with the default configuration (no withRetry call) the
+     * client must not retry. A connection-refused failure is therefore attempted
+     * exactly once, preserving the original fail-fast behaviour.
+     */
+    @Test
+    void testDefaultConfigurationDoesNotRetry() throws Exception {
+        Path tokenFile = writeTokenFile();
+
+        int port;
+        try (ServerSocket s = new ServerSocket(0)) {
+            port = s.getLocalPort();
+        }
+
+        // No withRetry(...) call -> rely on the default (retry disabled).
         BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port));
 
         long start = System.currentTimeMillis();
@@ -51,23 +86,28 @@ class BaoClientTest {
                 () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
         long elapsed = System.currentTimeMillis() - start;
 
-        Assertions.assertEquals(
-                "Failed to send POST to http://127.0.0.1:" + port + "/v1/auth/kubernetes/login: java.net.ConnectException",
-                ex.getMessage());
-        Assertions.assertTrue(elapsed < 1000, "Expected connection refused immediately but took " + elapsed + "ms");
+        // Default retry-max is 0 -> single attempt, no backoff.
+        Assertions.assertTrue(ex.getMessage().contains("after 1 attempt(s)"), ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("java.net.ConnectException"), ex.getMessage());
+        Assertions.assertTrue(elapsed < 1000, "Expected a single fail-fast attempt but took " + elapsed + "ms");
     }
 
     /**
-     * Test connect timeout.
-     * Uses a non-routable IP address so that SYN packets are silently dropped,
-     * causing HttpConnectTimeoutException after CONNECTION_TIMEOUT.
+     * Connection refused with retry enabled: connect-phase failures are retried
+     * up to maxRetries times (so maxRetries + 1 total attempts), applying backoff
+     * between attempts, before finally failing.
      */
     @Test
-    void testConnectTimeout() throws Exception {
-        Path tokenFile = tempDir.resolve("token");
-        Files.writeString(tokenFile, "dummy-jwt-token");
+    void testConnectionRefusedExhaustsRetries() throws Exception {
+        Path tokenFile = writeTokenFile();
 
-        BaoClient client = new BaoClient(URI.create("http://192.0.2.1:8200"));
+        int port;
+        try (ServerSocket s = new ServerSocket(0)) {
+            port = s.getLocalPort();
+        }
+
+        BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port))
+                .withRetry(2, Duration.ofMillis(100));
 
         long start = System.currentTimeMillis();
         RestClientException ex = Assertions.assertThrows(
@@ -75,22 +115,99 @@ class BaoClientTest {
                 () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
         long elapsed = System.currentTimeMillis() - start;
 
-        Assertions.assertEquals(
-                "Failed to send POST to http://192.0.2.1:8200/v1/auth/kubernetes/login: java.net.http.HttpConnectTimeoutException: HTTP connect timed out",
-                ex.getMessage());
-        Assertions.assertTrue(elapsed >= 3000 && elapsed < 6000,
-                "Expected connect timeout after ~3s but took " + elapsed + "ms");
+        // 2 retries -> 3 total attempts.
+        Assertions.assertTrue(ex.getMessage().contains("after 3 attempt(s)"), ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("java.net.ConnectException"), ex.getMessage());
+        // Backoff is scaled per attempt: 100ms + 200ms = 300ms minimum spent sleeping.
+        Assertions.assertTrue(elapsed >= 300,
+                "Expected at least 300ms of retry backoff but took only " + elapsed + "ms");
     }
 
     /**
-     * Test request timeout.
-     * Uses a server that accepts TCP connections but never responds,
-     * causing HttpTimeoutException after REQUEST_TIMEOUT.
+     * Connect-phase failure that recovers: the first attempts are refused because
+     * nothing is listening yet, then the server comes up and a subsequent retry
+     * succeeds. Verifies that retry actually recovers from a transient outage
+     * (the transient backend unavailability scenario, e.g. a restart or failover).
      */
     @Test
-    void testRequestTimeout() throws Exception {
-        Path tokenFile = tempDir.resolve("token");
-        Files.writeString(tokenFile, "dummy-jwt-token");
+    void testRetriesThenSucceedsWhenServerComesUp() throws Exception {
+        Path tokenFile = writeTokenFile();
+
+        // Reserve a port, then free it so the initial connect attempts are refused.
+        int port;
+        try (ServerSocket s = new ServerSocket(0)) {
+            port = s.getLocalPort();
+        }
+
+        String responseBody = "{\"auth\":{\"client_token\":\"test-token\"}}";
+        String httpResponse = "HTTP/1.1 200 OK\r\n"
+                + "Content-Type: application/json\r\n"
+                + "Content-Length: " + responseBody.length() + "\r\n"
+                + "\r\n"
+                + responseBody;
+
+        // Start the server only after a short delay so the first connect attempt(s) fail.
+        Thread server = new Thread(() -> {
+            try {
+                Thread.sleep(300);
+                try (ServerSocket ss = new ServerSocket(port);
+                        Socket conn = ss.accept()) {
+                    conn.getInputStream().readNBytes(1);
+                    OutputStream out = conn.getOutputStream();
+                    out.write(httpResponse.getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                }
+            } catch (IOException | InterruptedException ignored) {
+                // Test will fail via the assertion below if the server never serves.
+            }
+        });
+        server.setDaemon(true);
+        server.start();
+
+        BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port))
+                .withConnectTimeout(Duration.ofMillis(500))
+                .withRetry(10, Duration.ofMillis(150));
+
+        // Should recover once the server is up; no exception is thrown.
+        Assertions.assertDoesNotThrow(
+                () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
+
+        server.join(5000);
+    }
+
+    /**
+     * Connect timeout: uses a non-routable IP address so SYN packets are silently
+     * dropped, causing HttpConnectTimeoutException. With retry disabled it fails
+     * after a single attempt once the (shortened) connect timeout elapses.
+     */
+    @Test
+    void testConnectTimeoutNoRetry() throws Exception {
+        Path tokenFile = writeTokenFile();
+
+        BaoClient client = new BaoClient(URI.create("http://192.0.2.1:8200"))
+                .withConnectTimeout(Duration.ofSeconds(2))
+                .withRetry(0, Duration.ZERO);
+
+        long start = System.currentTimeMillis();
+        RestClientException ex = Assertions.assertThrows(
+                RestClientException.class,
+                () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
+        long elapsed = System.currentTimeMillis() - start;
+
+        Assertions.assertTrue(ex.getMessage().contains("after 1 attempt(s)"), ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("HttpConnectTimeoutException"), ex.getMessage());
+        Assertions.assertTrue(elapsed >= 2000 && elapsed < 5000,
+                "Expected connect timeout after ~2s but took " + elapsed + "ms");
+    }
+
+    /**
+     * Request timeout: a server accepts the TCP connection but never responds. This
+     * is a post-connection failure (HttpTimeoutException), which must NOT be retried
+     * because the request may already have reached the server.
+     */
+    @Test
+    void testRequestTimeoutIsNotRetried() throws Exception {
+        Path tokenFile = writeTokenFile();
 
         try (ServerSocket server = new ServerSocket(0)) {
             Thread acceptor = new Thread(() -> {
@@ -105,8 +222,9 @@ class BaoClientTest {
             acceptor.setDaemon(true);
             acceptor.start();
 
-            BaoClient client = new BaoClient(
-                    URI.create("http://127.0.0.1:" + server.getLocalPort()));
+            BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + server.getLocalPort()))
+                    .withRequestTimeout(Duration.ofSeconds(2))
+                    .withRetry(3, Duration.ofMillis(100));
 
             long start = System.currentTimeMillis();
             RestClientException ex = Assertions.assertThrows(
@@ -114,21 +232,23 @@ class BaoClientTest {
                     () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
             long elapsed = System.currentTimeMillis() - start;
 
-            Assertions.assertEquals(
-                    "Failed to send POST to http://127.0.0.1:" + server.getLocalPort() + "/v1/auth/kubernetes/login: java.net.http.HttpTimeoutException: request timed out",
-                    ex.getMessage());
-            Assertions.assertTrue(elapsed >= 10000 && elapsed < 13000,
-                    "Expected request timeout after ~10s but took " + elapsed + "ms");
+            Assertions.assertTrue(ex.getMessage().contains("HttpTimeoutException"), ex.getMessage());
+            // Not a connect-phase failure -> no retry -> message must not mention attempts.
+            Assertions.assertFalse(ex.getMessage().contains("attempt(s)"), ex.getMessage());
+            // A single ~2s request timeout, not multiplied by retries.
+            Assertions.assertTrue(elapsed >= 2000 && elapsed < 5000,
+                    "Expected a single request timeout after ~2s but took " + elapsed + "ms");
         }
     }
 
     /**
-     * Test HTTP error status response (500).
+     * HTTP error status response (500) after a successful connection is a response,
+     * not a connect-phase failure, so it must not be retried and surfaces as a
+     * BaoClientException carrying the status code.
      */
     @Test
     void testErrorStatusResponse() throws Exception {
-        Path tokenFile = tempDir.resolve("token");
-        Files.writeString(tokenFile, "dummy-jwt-token");
+        Path tokenFile = writeTokenFile();
 
         String responseBody = "{\"errors\":[\"permission denied\"]}";
         String httpResponse = "HTTP/1.1 500 Internal Server Error\r\n"
@@ -163,7 +283,8 @@ class BaoClientTest {
 
             Assertions.assertEquals(500, ex.getStatusCode());
             Assertions.assertEquals(
-                    "Failed to log in to http://127.0.0.1:" + server.getLocalPort() + ". HTTP response code 500 body: " + responseBody,
+                    "Failed to log in to http://127.0.0.1:" + server.getLocalPort()
+                            + ". HTTP response code 500 body: " + responseBody,
                     ex.getMessage());
             Assertions.assertTrue(elapsed < 1000, "Expected error response immediately but took " + elapsed + "ms");
         }

--- a/src/test/java/io/github/nordix/baoclient/BaoClientTest.java
+++ b/src/test/java/io/github/nordix/baoclient/BaoClientTest.java
@@ -29,19 +29,14 @@ class BaoClientTest {
     @TempDir
     Path tempDir;
 
-    private Path writeTokenFile() throws IOException {
-        Path tokenFile = tempDir.resolve("token");
-        Files.writeString(tokenFile, "dummy-jwt-token");
-        return tokenFile;
-    }
-
     /**
-     * Connection refused with retry disabled: the request is attempted exactly once
-     * (ConnectException) and fails fast.
+     * Test connection refused.
+     * Uses a free port that is not listening, causing ConnectException.
      */
     @Test
-    void testConnectionRefusedNoRetry() throws Exception {
-        Path tokenFile = writeTokenFile();
+    void testConnectionRefused() throws Exception {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "dummy-jwt-token");
 
         // Find a free port, then close it so nothing is listening on it.
         int port;
@@ -49,35 +44,6 @@ class BaoClientTest {
             port = s.getLocalPort();
         }
 
-        BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port))
-                .withRetry(0, Duration.ZERO);
-
-        long start = System.currentTimeMillis();
-        RestClientException ex = Assertions.assertThrows(
-                RestClientException.class,
-                () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
-        long elapsed = System.currentTimeMillis() - start;
-
-        Assertions.assertTrue(ex.getMessage().contains("after 1 attempt(s)"), ex.getMessage());
-        Assertions.assertTrue(ex.getMessage().contains("java.net.ConnectException"), ex.getMessage());
-        Assertions.assertTrue(elapsed < 1000, "Expected connection refused immediately but took " + elapsed + "ms");
-    }
-
-    /**
-     * Retry is opt-in: with the default configuration (no withRetry call) the
-     * client must not retry. A connection-refused failure is therefore attempted
-     * exactly once, preserving the original fail-fast behaviour.
-     */
-    @Test
-    void testDefaultConfigurationDoesNotRetry() throws Exception {
-        Path tokenFile = writeTokenFile();
-
-        int port;
-        try (ServerSocket s = new ServerSocket(0)) {
-            port = s.getLocalPort();
-        }
-
-        // No withRetry(...) call -> rely on the default (retry disabled).
         BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port));
 
         long start = System.currentTimeMillis();
@@ -86,28 +52,23 @@ class BaoClientTest {
                 () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
         long elapsed = System.currentTimeMillis() - start;
 
-        // Default retry-max is 0 -> single attempt, no backoff.
-        Assertions.assertTrue(ex.getMessage().contains("after 1 attempt(s)"), ex.getMessage());
-        Assertions.assertTrue(ex.getMessage().contains("java.net.ConnectException"), ex.getMessage());
-        Assertions.assertTrue(elapsed < 1000, "Expected a single fail-fast attempt but took " + elapsed + "ms");
+        Assertions.assertEquals(
+                "Failed to send POST to http://127.0.0.1:" + port + "/v1/auth/kubernetes/login: java.net.ConnectException",
+                ex.getMessage());
+        Assertions.assertTrue(elapsed < 1000, "Expected connection refused immediately but took " + elapsed + "ms");
     }
 
     /**
-     * Connection refused with retry enabled: connect-phase failures are retried
-     * up to maxRetries times (so maxRetries + 1 total attempts), applying backoff
-     * between attempts, before finally failing.
+     * Test connect timeout.
+     * Uses a non-routable IP address so that SYN packets are silently dropped,
+     * causing HttpConnectTimeoutException after the default connect timeout.
      */
     @Test
-    void testConnectionRefusedExhaustsRetries() throws Exception {
-        Path tokenFile = writeTokenFile();
+    void testConnectTimeout() throws Exception {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "dummy-jwt-token");
 
-        int port;
-        try (ServerSocket s = new ServerSocket(0)) {
-            port = s.getLocalPort();
-        }
-
-        BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port))
-                .withRetry(2, Duration.ofMillis(100));
+        BaoClient client = new BaoClient(URI.create("http://192.0.2.1:8200"));
 
         long start = System.currentTimeMillis();
         RestClientException ex = Assertions.assertThrows(
@@ -115,78 +76,64 @@ class BaoClientTest {
                 () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
         long elapsed = System.currentTimeMillis() - start;
 
-        // 2 retries -> 3 total attempts.
-        Assertions.assertTrue(ex.getMessage().contains("after 3 attempt(s)"), ex.getMessage());
-        Assertions.assertTrue(ex.getMessage().contains("java.net.ConnectException"), ex.getMessage());
-        // Backoff is scaled per attempt: 100ms + 200ms = 300ms minimum spent sleeping.
-        Assertions.assertTrue(elapsed >= 300,
-                "Expected at least 300ms of retry backoff but took only " + elapsed + "ms");
+        Assertions.assertEquals(
+                "Failed to send POST to http://192.0.2.1:8200/v1/auth/kubernetes/login: java.net.http.HttpConnectTimeoutException: HTTP connect timed out",
+                ex.getMessage());
+        Assertions.assertTrue(elapsed >= 3000 && elapsed < 6000,
+                "Expected connect timeout after ~3s but took " + elapsed + "ms");
     }
 
     /**
-     * Connect-phase failure that recovers: the first attempts are refused because
-     * nothing is listening yet, then the server comes up and a subsequent retry
-     * succeeds. Verifies that retry actually recovers from a transient outage
-     * (the transient backend unavailability scenario, e.g. a restart or failover).
+     * Test request timeout.
+     * Uses a server that accepts TCP connections but never responds,
+     * causing HttpTimeoutException after REQUEST_TIMEOUT.
      */
     @Test
-    void testRetriesThenSucceedsWhenServerComesUp() throws Exception {
-        Path tokenFile = writeTokenFile();
+    void testRequestTimeout() throws Exception {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "dummy-jwt-token");
 
-        // Reserve a port, then free it so the initial connect attempts are refused.
-        int port;
-        try (ServerSocket s = new ServerSocket(0)) {
-            port = s.getLocalPort();
-        }
-
-        String responseBody = "{\"auth\":{\"client_token\":\"test-token\"}}";
-        String httpResponse = "HTTP/1.1 200 OK\r\n"
-                + "Content-Type: application/json\r\n"
-                + "Content-Length: " + responseBody.length() + "\r\n"
-                + "\r\n"
-                + responseBody;
-
-        // Start the server only after a short delay so the first connect attempt(s) fail.
-        Thread server = new Thread(() -> {
-            try {
-                Thread.sleep(300);
-                try (ServerSocket ss = new ServerSocket(port);
-                        Socket conn = ss.accept()) {
-                    conn.getInputStream().readNBytes(1);
-                    OutputStream out = conn.getOutputStream();
-                    out.write(httpResponse.getBytes(StandardCharsets.UTF_8));
-                    out.flush();
+        try (ServerSocket server = new ServerSocket(0)) {
+            Thread acceptor = new Thread(() -> {
+                while (!server.isClosed()) {
+                    try {
+                        server.accept(); // Accept but never write anything.
+                    } catch (IOException ignored) {
+                        // Expected once the server socket is closed at the end of the test.
+                    }
                 }
-            } catch (IOException | InterruptedException ignored) {
-                // Test will fail via the assertion below if the server never serves.
-            }
-        });
-        server.setDaemon(true);
-        server.start();
+            });
+            acceptor.setDaemon(true);
+            acceptor.start();
 
-        BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + port))
-                .withConnectTimeout(Duration.ofMillis(500))
-                .withRetry(10, Duration.ofMillis(150));
+            BaoClient client = new BaoClient(
+                    URI.create("http://127.0.0.1:" + server.getLocalPort()));
 
-        // Should recover once the server is up; no exception is thrown.
-        Assertions.assertDoesNotThrow(
-                () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
+            long start = System.currentTimeMillis();
+            RestClientException ex = Assertions.assertThrows(
+                    RestClientException.class,
+                    () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
+            long elapsed = System.currentTimeMillis() - start;
 
-        server.join(5000);
+            Assertions.assertEquals(
+                    "Failed to send POST to http://127.0.0.1:" + server.getLocalPort() + "/v1/auth/kubernetes/login: java.net.http.HttpTimeoutException: request timed out",
+                    ex.getMessage());
+            Assertions.assertTrue(elapsed >= 10000 && elapsed < 13000,
+                    "Expected request timeout after ~10s but took " + elapsed + "ms");
+        }
     }
 
     /**
-     * Connect timeout: uses a non-routable IP address so SYN packets are silently
-     * dropped, causing HttpConnectTimeoutException. With retry disabled it fails
-     * after a single attempt once the (shortened) connect timeout elapses.
+     * The connect timeout is configurable and the configured value takes effect.
+     * Shortens it to 1s and asserts the failure arrives well before the 3s default.
      */
     @Test
-    void testConnectTimeoutNoRetry() throws Exception {
-        Path tokenFile = writeTokenFile();
+    void testConnectTimeoutIsConfigurable() throws Exception {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "dummy-jwt-token");
 
         BaoClient client = new BaoClient(URI.create("http://192.0.2.1:8200"))
-                .withConnectTimeout(Duration.ofSeconds(2))
-                .withRetry(0, Duration.ZERO);
+                .withConnectTimeout(Duration.ofSeconds(1));
 
         long start = System.currentTimeMillis();
         RestClientException ex = Assertions.assertThrows(
@@ -194,20 +141,20 @@ class BaoClientTest {
                 () -> client.loginWithKubernetes(tokenFile.toString(), "test-role"));
         long elapsed = System.currentTimeMillis() - start;
 
-        Assertions.assertTrue(ex.getMessage().contains("after 1 attempt(s)"), ex.getMessage());
         Assertions.assertTrue(ex.getMessage().contains("HttpConnectTimeoutException"), ex.getMessage());
-        Assertions.assertTrue(elapsed >= 2000 && elapsed < 5000,
-                "Expected connect timeout after ~2s but took " + elapsed + "ms");
+        Assertions.assertTrue(elapsed >= 1000 && elapsed < 3000,
+                "Expected connect timeout after ~1s but took " + elapsed + "ms");
     }
 
     /**
-     * Request timeout: a server accepts the TCP connection but never responds. This
-     * is a post-connection failure (HttpTimeoutException), which must NOT be retried
-     * because the request may already have reached the server.
+     * The request timeout is configurable and the configured value takes effect.
+     * Shortens it to 2s against a server that accepts the connection but never
+     * responds, and asserts the failure arrives well before the 10s default.
      */
     @Test
-    void testRequestTimeoutIsNotRetried() throws Exception {
-        Path tokenFile = writeTokenFile();
+    void testRequestTimeoutIsConfigurable() throws Exception {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "dummy-jwt-token");
 
         try (ServerSocket server = new ServerSocket(0)) {
             Thread acceptor = new Thread(() -> {
@@ -223,8 +170,7 @@ class BaoClientTest {
             acceptor.start();
 
             BaoClient client = new BaoClient(URI.create("http://127.0.0.1:" + server.getLocalPort()))
-                    .withRequestTimeout(Duration.ofSeconds(2))
-                    .withRetry(3, Duration.ofMillis(100));
+                    .withRequestTimeout(Duration.ofSeconds(2));
 
             long start = System.currentTimeMillis();
             RestClientException ex = Assertions.assertThrows(
@@ -233,22 +179,18 @@ class BaoClientTest {
             long elapsed = System.currentTimeMillis() - start;
 
             Assertions.assertTrue(ex.getMessage().contains("HttpTimeoutException"), ex.getMessage());
-            // Not a connect-phase failure -> no retry -> message must not mention attempts.
-            Assertions.assertFalse(ex.getMessage().contains("attempt(s)"), ex.getMessage());
-            // A single ~2s request timeout, not multiplied by retries.
             Assertions.assertTrue(elapsed >= 2000 && elapsed < 5000,
-                    "Expected a single request timeout after ~2s but took " + elapsed + "ms");
+                    "Expected request timeout after ~2s but took " + elapsed + "ms");
         }
     }
 
     /**
-     * HTTP error status response (500) after a successful connection is a response,
-     * not a connect-phase failure, so it must not be retried and surfaces as a
-     * BaoClientException carrying the status code.
+     * Test HTTP error status response (500).
      */
     @Test
     void testErrorStatusResponse() throws Exception {
-        Path tokenFile = writeTokenFile();
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "dummy-jwt-token");
 
         String responseBody = "{\"errors\":[\"permission denied\"]}";
         String httpResponse = "HTTP/1.1 500 Internal Server Error\r\n"
@@ -283,8 +225,7 @@ class BaoClientTest {
 
             Assertions.assertEquals(500, ex.getStatusCode());
             Assertions.assertEquals(
-                    "Failed to log in to http://127.0.0.1:" + server.getLocalPort()
-                            + ". HTTP response code 500 body: " + responseBody,
+                    "Failed to log in to http://127.0.0.1:" + server.getLocalPort() + ". HTTP response code 500 body: " + responseBody,
                     ex.getMessage());
             Assertions.assertTrue(elapsed < 1000, "Expected error response immediately but took " + elapsed + "ms");
         }

--- a/src/test/java/io/github/nordix/keycloak/common/ProviderConfigTest.java
+++ b/src/test/java/io/github/nordix/keycloak/common/ProviderConfigTest.java
@@ -102,35 +102,29 @@ class ProviderConfigTest {
     }
 
     /**
-     * With none of the resilience options set, the defaults must preserve the previous
-     * behaviour: connect 3s, request 10s, and retry disabled (retry-max = 0).
+     * With neither timeout option set, the defaults must preserve the previous
+     * hard-coded behaviour: connect 3s, request 10s.
      */
     @Test
-    void testResilienceDefaults() throws IOException {
+    void testTimeoutDefaults() throws IOException {
         ProviderConfig config = new ProviderConfig(new MapScope(baseOptions()), "test-");
 
         Assertions.assertEquals(3, config.getConnectTimeoutSeconds());
         Assertions.assertEquals(10, config.getRequestTimeoutSeconds());
-        Assertions.assertEquals(0, config.getRetryMax());
-        Assertions.assertEquals(2, config.getRetryBackoffSeconds());
     }
 
     /**
-     * When the resilience options are provided, they are parsed and exposed via the getters.
+     * When the timeout options are provided, they are parsed and exposed via the getters.
      */
     @Test
-    void testResilienceOptionsAreParsed() throws IOException {
+    void testTimeoutOptionsAreParsed() throws IOException {
         Map<String, String> options = baseOptions();
         options.put("connect-timeout-seconds", "5");
         options.put("request-timeout-seconds", "20");
-        options.put("retry-max", "3");
-        options.put("retry-backoff-seconds", "1");
 
         ProviderConfig config = new ProviderConfig(new MapScope(options), "test-");
 
         Assertions.assertEquals(5, config.getConnectTimeoutSeconds());
         Assertions.assertEquals(20, config.getRequestTimeoutSeconds());
-        Assertions.assertEquals(3, config.getRetryMax());
-        Assertions.assertEquals(1, config.getRetryBackoffSeconds());
     }
 }

--- a/src/test/java/io/github/nordix/keycloak/common/ProviderConfigTest.java
+++ b/src/test/java/io/github/nordix/keycloak/common/ProviderConfigTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2026 OpenInfra Foundation Europe and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License, Version 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.github.nordix.keycloak.common;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.keycloak.Config.Scope;
+
+class ProviderConfigTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path writeTokenFile() throws IOException {
+        Path tokenFile = tempDir.resolve("token");
+        Files.writeString(tokenFile, "dummy-jwt-token");
+        return tokenFile;
+    }
+
+    /**
+     * Minimal map-backed Config.Scope test double. ProviderConfig reads options only via
+     * get(key) and get(key, defaultValue); the remaining Scope methods are not exercised.
+     */
+    @SuppressWarnings("deprecation") // A deprecated Scope method is overridden but never used by ProviderConfig.
+    private static final class MapScope implements Scope {
+
+        private final Map<String, String> values;
+
+        MapScope(Map<String, String> values) {
+            this.values = values;
+        }
+
+        @Override
+        public String get(String key) {
+            return values.get(key);
+        }
+
+        @Override
+        public String get(String key, String defaultValue) {
+            return values.getOrDefault(key, defaultValue);
+        }
+
+        @Override
+        public String[] getArray(String key) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Integer getInt(String key, Integer defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Long getLong(String key, Long defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Boolean getBoolean(String key, Boolean defaultValue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Scope scope(String... scope) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Scope root() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Build the minimum set of options required to satisfy the ProviderConfig constructor
+     * validation (a reachable address and a readable service-account token file).
+     */
+    private Map<String, String> baseOptions() throws IOException {
+        Map<String, String> options = new HashMap<>();
+        options.put("address", "http://localhost:8200");
+        options.put("service-account-file", writeTokenFile().toString());
+        return options;
+    }
+
+    /**
+     * With none of the resilience options set, the defaults must preserve the previous
+     * behaviour: connect 3s, request 10s, and retry disabled (retry-max = 0).
+     */
+    @Test
+    void testResilienceDefaults() throws IOException {
+        ProviderConfig config = new ProviderConfig(new MapScope(baseOptions()), "test-");
+
+        Assertions.assertEquals(3, config.getConnectTimeoutSeconds());
+        Assertions.assertEquals(10, config.getRequestTimeoutSeconds());
+        Assertions.assertEquals(0, config.getRetryMax());
+        Assertions.assertEquals(2, config.getRetryBackoffSeconds());
+    }
+
+    /**
+     * When the resilience options are provided, they are parsed and exposed via the getters.
+     */
+    @Test
+    void testResilienceOptionsAreParsed() throws IOException {
+        Map<String, String> options = baseOptions();
+        options.put("connect-timeout-seconds", "5");
+        options.put("request-timeout-seconds", "20");
+        options.put("retry-max", "3");
+        options.put("retry-backoff-seconds", "1");
+
+        ProviderConfig config = new ProviderConfig(new MapScope(options), "test-");
+
+        Assertions.assertEquals(5, config.getConnectTimeoutSeconds());
+        Assertions.assertEquals(20, config.getRequestTimeoutSeconds());
+        Assertions.assertEquals(3, config.getRetryMax());
+        Assertions.assertEquals(1, config.getRetryBackoffSeconds());
+    }
+}


### PR DESCRIPTION
 ## What
  
Make the OpenBao/Vault client's connection settings configurable. The connect and request timeouts were hard-coded in `RestClient`; they are now per-instance and exposed as SPI options on both the vault `secrets-provider` and the
`secrets-manager` REST resource.
  
Fixes #180.
  
  | Option | Description | Default |
  |---|---|---|
  | `connect-timeout-seconds` | Timeout for establishing the connection to the server | `3` (unchanged) |
  | `request-timeout-seconds` | Timeout for a single request to the server | `10` (unchanged) |
  
The defaults match the previously hard-coded values, so behaviour is unchanged unless a deployment chooses to tune them — shorter to fail fast, or longer to tolerate a brief transient stall.
  
  ## Why no retry in the client
  
  The first commit also added an optional connect retry. The second commit removes
  it, narrowing this PR to the timeouts only. Retry inside this client cannot make
  the operation reliable on its own:
  
  - It covers only the connection phase, so it misses the redirect and error responses that occur in the same backend restart window.
  - It can re-send a single request, but cannot redo the authenticate-then-read sequence as a whole.
  - The caller owns the operation end-to-end and is the layer that can re-authenticate and re-issue it. Callers that need to ride out a transient backend outage already retry at that level.
  
  Configurable timeouts are what this client can usefully offer: control over how long a single attempt may take, before the caller's own retry takes over.
  
  ## Tests
  
  - `ProviderConfigTest` — defaults are unchanged, and both options are parsed.
  - `BaoClientTest` — existing coverage of the default connect and request timeouts is retained, plus two new cases asserting each timeout is configurable and that the configured value takes effect.
  
  `./mvnw checkstyle:check` passes.