### PR TITLE
make keycloakAdminClient static

### DIFF
--- a/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/secretsmanager/SecretsManagerIT.java
@@ -39,7 +39,7 @@ class SecretsManagerIT {
     private static final String OPENBAO_METRICS_URL = OPENBAO_BASE_URL + "/v1/sys/metrics?format=prometheus";
 
     @RegisterExtension
-    private final KeycloakRestClientExtension keycloakAdminClient = new KeycloakRestClientExtension(
+    private static final KeycloakRestClientExtension keycloakAdminClient = new KeycloakRestClientExtension(
             KEYCLOAK_BASE_URL);
 
     private static final String REALM = "secrets-manager-test-realm";


### PR DESCRIPTION
Fix SecretsManagerIT by making keycloakAdminClient static to guarantee waitForReady() runs before TestRealm creates the realm